### PR TITLE
Improve NuGet workflow

### DIFF
--- a/.github/workflows/NuGet Solution Master Workflow.yml
+++ b/.github/workflows/NuGet Solution Master Workflow.yml
@@ -193,7 +193,7 @@ jobs:
     # Signing cannot be done from linux environment (https://github.com/dotnet/runtime/issues/48794)
   sign:
     # Don't run the signing when dependabot branch/pull request
-    if: ${{ github.secret_source != 'Dependabot' }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     # The type of runner that the job will run on
     runs-on: windows-latest
     needs: validate_skyline_quality_gate

--- a/.github/workflows/NuGet Solution Master Workflow.yml
+++ b/.github/workflows/NuGet Solution Master Workflow.yml
@@ -192,7 +192,9 @@ jobs:
 
     # Signing cannot be done from linux environment (https://github.com/dotnet/runtime/issues/48794)
   sign:
-      # The type of runner that the job will run on
+    # Don't run the signing when dependabot branch/pull request
+    if: ${{ github.secret_source != 'Dependabot' }}
+    # The type of runner that the job will run on
     runs-on: windows-latest
     needs: validate_skyline_quality_gate
     steps:


### PR DESCRIPTION
Don't do the signing step when it's a dependabot branch/pull request.