### PR TITLE
Adding fetch-depth 0 to each workflow that also goes to SonarCloud.

### DIFF
--- a/.github/workflows/Automation Master Legacy Workflow.yml
+++ b/.github/workflows/Automation Master Legacy Workflow.yml
@@ -50,6 +50,8 @@ jobs:
       quality: ${{ steps.quality-step.outputs.results }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Initialize
         run: |

--- a/.github/workflows/Automation Master SDK Workflow.yml
+++ b/.github/workflows/Automation Master SDK Workflow.yml
@@ -50,6 +50,8 @@ jobs:
       quality: ${{ steps.quality-step.outputs.results }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Initialize
         run: |

--- a/.github/workflows/Connector Master Legacy Workflow.yml
+++ b/.github/workflows/Connector Master Legacy Workflow.yml
@@ -50,6 +50,8 @@ jobs:
       quality: ${{ steps.quality-step.outputs.results }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Initialize
         run: |

--- a/.github/workflows/Connector Master SDK Workflow.yml
+++ b/.github/workflows/Connector Master SDK Workflow.yml
@@ -48,6 +48,8 @@ jobs:
       quality: ${{ steps.quality-step.outputs.results }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Initialize
         run: |

--- a/.github/workflows/Internal NuGet Solution Master Workflow.yml
+++ b/.github/workflows/Internal NuGet Solution Master Workflow.yml
@@ -42,6 +42,8 @@ jobs:
       quality: ${{ steps.quality-step.outputs.results }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Initialize
         run: |

--- a/.github/workflows/NuGet Solution Master Workflow.yml
+++ b/.github/workflows/NuGet Solution Master Workflow.yml
@@ -46,6 +46,8 @@ jobs:
       quality: ${{ steps.quality-step.outputs.results }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Initialize
         run: |


### PR DESCRIPTION
Option is needed so that SonarCloud can track who is the cause of each error in SonarCloud. This way the issues are auto-assigned to the correct person.