### PR TITLE
Specify previous version of the ubuntu runner image for the legacy style project workflows

### DIFF
--- a/.github/workflows/Automation Master Legacy Workflow.yml
+++ b/.github/workflows/Automation Master Legacy Workflow.yml
@@ -281,7 +281,8 @@ jobs:
 
   artifact_creation:
       name: Artifact Creation
-      runs-on: ubuntu-latest
+      # ubuntu-latest (24.04) does not yet support mono / MSBuild / NuGet (https://github.com/actions/runner-images/issues/10636)
+      runs-on: ubuntu-22.04
       steps:
         # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
         - uses: actions/checkout@v4

--- a/.github/workflows/Connector Master Legacy Workflow.yml
+++ b/.github/workflows/Connector Master Legacy Workflow.yml
@@ -281,7 +281,8 @@ jobs:
 
   artifact_creation_registration:
     name: Artifact Creation
-    runs-on: ubuntu-latest
+    # ubuntu-latest (24.04) does not yet support mono / MSBuild / NuGet (https://github.com/actions/runner-images/issues/10636)
+    runs-on: ubuntu-22.04
     needs: validate_skyline_quality_gate
     env:
       result-artifact-id: none


### PR DESCRIPTION
Latest ubuntu image doesn't support mono/msbuild/nuget yet: https://github.com/actions/runner-images/issues/10636