### PR TITLE
Master Workflow - Specify NuGet output location

### DIFF
--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -648,7 +648,8 @@ jobs:
             --configuration "$CONFIGURATION" \
             -p:CatalogPublishKeyName="DATAMINER_TOKEN" \
             -p:CatalogDefaultDownloadKeyName="OVERRIDE_CATALOG_DOWNLOAD_TOKEN" \
-            -p:SkylineDataMinerSdkDebug="$DEBUG_FLAG"
+            -p:SkylineDataMinerSdkDebug="$DEBUG_FLAG" \
+            -p:PackageOutputPath="${GITHUB_WORKSPACE}/_NuGetOutput"
 
       # ──────────────────────────────────────────────────────────────
       # D. Test & Quality Gate
@@ -758,10 +759,12 @@ jobs:
       - name: Detect NuGet packages
         if: github.actor != 'dependabot[bot]'
         id: detect-nuget-packages
-        env:
-          CONFIGURATION: ${{ inputs.configuration }}
         run: |
-          nuget_count=$(find . -path "*/bin/$CONFIGURATION/*.nupkg" | wc -l)
+          if [ -d "_NuGetOutput" ]; then
+            nuget_count=$(find _NuGetOutput -name "*.nupkg" | wc -l)
+          else
+            nuget_count=0
+          fi
           if [ "$nuget_count" -gt 0 ]; then
             echo "Found $nuget_count NuGet package(s)"
             echo "has-nuget-packages=true" >> $GITHUB_OUTPUT
@@ -776,8 +779,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: NugetPackages
-          path: |
-            **/bin/${{ inputs.configuration }}/**/*.nupkg
+          path: _NuGetOutput/*.nupkg
 
       - name: Detect DataMiner packages
         if: github.actor != 'dependabot[bot]'


### PR DESCRIPTION
This pull request updates the build and packaging steps in the `.github/workflows/Master Workflow.yml` file to standardize the output location for NuGet packages and improve detection and upload logic. The main changes ensure that all generated NuGet packages are placed in a single `_NuGetOutput` directory, simplifying artifact handling and improving consistency.

**Build and Packaging Improvements:**

* Added the `-p:PackageOutputPath="${GITHUB_WORKSPACE}/_NuGetOutput"` parameter to the build step to direct all NuGet package outputs to a dedicated `_NuGetOutput` folder.

**Artifact Detection and Upload Updates:**

* Updated the NuGet package detection logic to look for `.nupkg` files specifically in the `_NuGetOutput` directory, ensuring accurate detection of generated packages.
* Changed the artifact upload step to upload NuGet packages from `_NuGetOutput/*.nupkg` instead of searching through all `bin` directories, streamlining the artifact collection process.


When using Verify.MSTest (or other equivalents) (via [EmptyFiles](https://github.com/VerifyTests/EmptyFiles)), it places a bunch of empty files in the bin folder (including an 'empty.nupkg'). This empty.nupkg was included in the release flow, which resulted in a failure as it isn't a valid NuGet package.