### PR TITLE
Block workflow runs on insecure trigger

### DIFF
--- a/.github/workflows/Automation Master Legacy Workflow.yml
+++ b/.github/workflows/Automation Master Legacy Workflow.yml
@@ -38,8 +38,20 @@ on:
         required: false
 
 jobs:
+
+  validate_trigger:
+    name: Validate Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsupported trigger
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "::error::This workflow does not support the 'pull_request_target' trigger. Use 'pull_request' instead to avoid security risks."
+          exit 1
+
   validate_skyline_quality_gate:
     name: Legacy Skyline Quality Gate
+    needs: [validate_trigger]
     runs-on: windows-latest
     env:
       detected-unit-tests: none

--- a/.github/workflows/Automation Master SDK Workflow.yml
+++ b/.github/workflows/Automation Master SDK Workflow.yml
@@ -38,8 +38,20 @@ on:
         required: false
 
 jobs:
+
+  validate_trigger:
+    name: Validate Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsupported trigger
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "::error::This workflow does not support the 'pull_request_target' trigger. Use 'pull_request' instead to avoid security risks."
+          exit 1
+
   validate_skyline_quality_gate:
     name: SDK Skyline Quality Gate 
+    needs: [validate_trigger]
     runs-on: windows-latest
     env:
       detected-unit-tests: none

--- a/.github/workflows/Automation Master Workflow.yml
+++ b/.github/workflows/Automation Master Workflow.yml
@@ -55,8 +55,20 @@ on:
         required: false
 
 jobs:
+
+  validate_trigger:
+    name: Validate Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsupported trigger
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "::error::This workflow does not support the 'pull_request_target' trigger. Use 'pull_request' instead to avoid security risks."
+          exit 1
+
   check_deprecated_item:
     name: Check deprecated items
+    needs: [validate_trigger]
     runs-on: ubuntu-latest
     steps:
       - name: Check if obsolete inputs are still used

--- a/.github/workflows/Connector Master Legacy Workflow.yml
+++ b/.github/workflows/Connector Master Legacy Workflow.yml
@@ -38,8 +38,20 @@ on:
         required: false
 
 jobs:
+
+  validate_trigger:
+    name: Validate Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsupported trigger
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "::error::This workflow does not support the 'pull_request_target' trigger. Use 'pull_request' instead to avoid security risks."
+          exit 1
+
   validate_skyline_quality_gate:
     name: Legacy Skyline Quality Gate
+    needs: [validate_trigger]
     runs-on: windows-latest
     env:
       detected-unit-tests: none

--- a/.github/workflows/Connector Master SDK Workflow.yml
+++ b/.github/workflows/Connector Master SDK Workflow.yml
@@ -38,8 +38,20 @@ on:
         required: false
 
 jobs:
+
+  validate_trigger:
+    name: Validate Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsupported trigger
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "::error::This workflow does not support the 'pull_request_target' trigger. Use 'pull_request' instead to avoid security risks."
+          exit 1
+
   validate_skyline_quality_gate:
     name: SDK Skyline Quality Gate
+    needs: [validate_trigger]
     runs-on: windows-latest
     outputs:
       quality: ${{ steps.quality-step.outputs.results }}

--- a/.github/workflows/Connector Master Workflow.yml
+++ b/.github/workflows/Connector Master Workflow.yml
@@ -56,8 +56,20 @@ on:
         required: false
 
 jobs:
+
+  validate_trigger:
+    name: Validate Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsupported trigger
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "::error::This workflow does not support the 'pull_request_target' trigger. Use 'pull_request' instead to avoid security risks."
+          exit 1
+
   check_deprecated_item:
     name: Check deprecated items
+    needs: [validate_trigger]
     runs-on: ubuntu-latest
     steps:
       - name: Check if obsolete inputs are still used

--- a/.github/workflows/DataMiner App Packages Master Workflow.yml
+++ b/.github/workflows/DataMiner App Packages Master Workflow.yml
@@ -67,8 +67,20 @@ on:
         required: false
 
 jobs:
+
+  validate_trigger:
+    name: Validate Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsupported trigger
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "::error::This workflow does not support the 'pull_request_target' trigger. Use 'pull_request' instead to avoid security risks."
+          exit 1
+
   check_deprecated_item:
     name: Check deprecated items
+    needs: [validate_trigger]
     runs-on: ubuntu-latest
     steps:
       - name: Check if obsolete inputs are still used

--- a/.github/workflows/Internal NuGet Solution Master Workflow.yml
+++ b/.github/workflows/Internal NuGet Solution Master Workflow.yml
@@ -51,8 +51,20 @@ on:
         required: false
 
 jobs:
+
+  validate_trigger:
+    name: Validate Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsupported trigger
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "::error::This workflow does not support the 'pull_request_target' trigger. Use 'pull_request' instead to avoid security risks."
+          exit 1
+
   check_deprecated_item:
     name: Check deprecated items
+    needs: [validate_trigger]
     runs-on: ubuntu-latest
     steps:
       - name: Check if obsolete inputs are still used

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -73,8 +73,19 @@ env:
 
 jobs:
 
+  validate_trigger:
+    name: Validate Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsupported trigger
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "::error::This workflow does not support the 'pull_request_target' trigger. Use 'pull_request' instead to avoid security risks."
+          exit 1
+
   check_oidc:
     name: Check OIDC
+    needs: [validate_trigger]
     runs-on: ubuntu-latest
     outputs:
       client-id: ${{ steps.set_oidc.outputs.client-id }}
@@ -115,6 +126,7 @@ jobs:
 
   discover_projects:
     name: Discover Project Types
+    needs: [validate_trigger]
     runs-on: ubuntu-latest
     outputs:
       has-dataminer-projects: ${{ steps.detect-projects.outputs.has-dataminer-projects }}

--- a/.github/workflows/NuGet Solution Master Workflow.yml
+++ b/.github/workflows/NuGet Solution Master Workflow.yml
@@ -55,8 +55,20 @@ on:
         required: false
 
 jobs:
+
+  validate_trigger:
+    name: Validate Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsupported trigger
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "::error::This workflow does not support the 'pull_request_target' trigger. Use 'pull_request' instead to avoid security risks."
+          exit 1
+
   check_deprecated_item:
     name: Check deprecated items
+    needs: [validate_trigger]
     runs-on: ubuntu-latest
     steps:
       - name: Check if obsolete inputs are still used

--- a/.github/workflows/SRM Function Master Workflow.yml
+++ b/.github/workflows/SRM Function Master Workflow.yml
@@ -37,8 +37,20 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+
+  validate_trigger:
+    name: Validate Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsupported trigger
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "::error::This workflow does not support the 'pull_request_target' trigger. Use 'pull_request' instead to avoid security risks."
+          exit 1
+
   validate_skyline_quality_gate:
     name: Skyline Quality Gate 
+    needs: [validate_trigger]
     runs-on: windows-latest
     env:
       detected-unit-tests: none

--- a/.github/workflows/Update Catalog Details Workflow.yml
+++ b/.github/workflows/Update Catalog Details Workflow.yml
@@ -26,8 +26,20 @@ on:
         required: false
 
 jobs:
+
+  validate_trigger:
+    name: Validate Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsupported trigger
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "::error::This workflow does not support the 'pull_request_target' trigger. Use 'pull_request' instead to avoid security risks."
+          exit 1
+
   check_oidc:
     name: Check OIDC
+    needs: [validate_trigger]
     runs-on: ubuntu-latest
     outputs:
       client-id: ${{ steps.set_oidc.outputs.client-id }}


### PR DESCRIPTION
This pull request enhances the security of all GitHub Actions workflows by ensuring they cannot be triggered using the less secure `pull_request_target` event. A new `validate_trigger` job is added to each workflow, which checks the event type and fails early with a clear error message if the workflow is started via `pull_request_target`. All other jobs in each workflow are updated to depend on this validation step, preventing accidental or malicious use of unsupported triggers.

**Security improvements to GitHub Actions workflows:**

* Added a `validate_trigger` job to each workflow (e.g., `.github/workflows/Master Workflow.yml`, `.github/workflows/Automation Master Workflow.yml`, etc.) that checks for the `pull_request_target` event and fails the workflow if detected, displaying a clear error message to the user. [[1]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R76-R88) [[2]](diffhunk://#diff-4ed55f0a7417a319bb5bd316272f03defbcf3bf42fcd213256a6abf22c779f3cR58-R71) [[3]](diffhunk://#diff-1102371d45100e78f5222b491e8e5963282a72e6c828c4661f53f1ffee7f9be1R41-R54) [[4]](diffhunk://#diff-ae570f578e172384a4ac076672ee776ebeeff1b1dbeeedd7abb07dde986346d3R41-R54) [[5]](diffhunk://#diff-9109b1b305c1eecf28ac8855d084f0106e40c8601a0bedcc03a307208234213dR41-R54) [[6]](diffhunk://#diff-0dace03534b5ffcaa75686dafb41e42bacd26eb889f471b2914408bce95e9cc9R59-R72) [[7]](diffhunk://#diff-3bcb2f553d3b78b8b1521140fdb6aa409253fe61d2bf5e97f49a218898eff9a3R70-R83) [[8]](diffhunk://#diff-a6e8a7b8870510ce8707d53ddb37ced185048e5a13f8184ccc5cd789bef50b11R54-R67) [[9]](diffhunk://#diff-dee734f9ce8a579fb29d897855751bff189ea2a007cef5a6216b12989f34926cR58-R71) [[10]](diffhunk://#diff-e8718f7e30b11ed66819824cbb38a00566e789648e33abeb0e9a034ee83a08f3R40-R53) [[11]](diffhunk://#diff-3093a8524fd0a2e42c51aa8a9773e6ce54e6d263237a09edbb560bb1538d8494R29-R42) [[12]](diffhunk://#diff-0fe005934d6b7bf17837b2222f0b5cdfb2788f672d684c93c4f288d32a3deae6R41-R54)

* Updated all subsequent jobs in each workflow to depend on the `validate_trigger` job by adding `needs: [validate_trigger]`, ensuring no job runs if the trigger validation fails. [[1]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R129) [[2]](diffhunk://#diff-4ed55f0a7417a319bb5bd316272f03defbcf3bf42fcd213256a6abf22c779f3cR58-R71) [[3]](diffhunk://#diff-1102371d45100e78f5222b491e8e5963282a72e6c828c4661f53f1ffee7f9be1R41-R54) [[4]](diffhunk://#diff-ae570f578e172384a4ac076672ee776ebeeff1b1dbeeedd7abb07dde986346d3R41-R54) [[5]](diffhunk://#diff-9109b1b305c1eecf28ac8855d084f0106e40c8601a0bedcc03a307208234213dR41-R54) [[6]](diffhunk://#diff-0dace03534b5ffcaa75686dafb41e42bacd26eb889f471b2914408bce95e9cc9R59-R72) [[7]](diffhunk://#diff-3bcb2f553d3b78b8b1521140fdb6aa409253fe61d2bf5e97f49a218898eff9a3R70-R83) [[8]](diffhunk://#diff-a6e8a7b8870510ce8707d53ddb37ced185048e5a13f8184ccc5cd789bef50b11R54-R67) [[9]](diffhunk://#diff-dee734f9ce8a579fb29d897855751bff189ea2a007cef5a6216b12989f34926cR58-R71) [[10]](diffhunk://#diff-e8718f7e30b11ed66819824cbb38a00566e789648e33abeb0e9a034ee83a08f3R40-R53) [[11]](diffhunk://#diff-3093a8524fd0a2e42c51aa8a9773e6ce54e6d263237a09edbb560bb1538d8494R29-R42) [[12]](diffhunk://#diff-0fe005934d6b7bf17837b2222f0b5cdfb2788f672d684c93c4f288d32a3deae6R41-R54)

These changes collectively ensure that all workflows can only be triggered by the supported and safer `pull_request` event, reducing the risk of privilege escalation or unintended code execution.