### PR TITLE
Add Connector SDK Migration workflow

### DIFF
--- a/.github/workflows/Connector Master Workflow.yml
+++ b/.github/workflows/Connector Master Workflow.yml
@@ -186,7 +186,7 @@ jobs:
   Request_SDK_Migration:
     name: Request SDK migration
     uses: ./.github/workflows/SDK Migration Workflow.yml
-    needs: [check_solution_type]
+    needs: [check_solution_type, check_oidc]
     # Trigger the agentic migration when the legacy path is taken, so
     # developers organically discover the migration PR while working on
     # old repos. Gating:
@@ -202,6 +202,10 @@ jobs:
     with:
       assume_legacy: true
       debug: ${{ inputs.debug }}
+      oidc-client-id: ${{ needs.check_oidc.outputs.client-id }}
+      oidc-tenant-id: ${{ needs.check_oidc.outputs.tenant-id }}
+      oidc-subscription-id: ${{ needs.check_oidc.outputs.subscription-id }}
+      use-oidc: ${{ needs.check_oidc.outputs.use-oidc }}
     secrets: inherit
 
   CI_SDK:

--- a/.github/workflows/Connector Master Workflow.yml
+++ b/.github/workflows/Connector Master Workflow.yml
@@ -202,6 +202,7 @@ jobs:
     with:
       assume_legacy: true
       debug: ${{ inputs.debug }}
+    secrets: inherit
 
   CI_SDK:
     uses: ./.github/workflows/Connector Master SDK Workflow.yml

--- a/.github/workflows/Connector Master Workflow.yml
+++ b/.github/workflows/Connector Master Workflow.yml
@@ -183,6 +183,26 @@ jobs:
       debug: ${{ inputs.debug }}
     secrets: inherit
 
+  Request_SDK_Migration:
+    name: Request SDK migration
+    uses: ./.github/workflows/SDK Migration Workflow.yml
+    needs: [check_solution_type]
+    # Trigger the agentic migration when the legacy path is taken, so
+    # developers organically discover the migration PR while working on
+    # old repos. Gating:
+    #   - Only when the solution is legacy-style.
+    #   - Only on push to the repo's default branch (avoids creating an
+    #     issue from every PR run or every feature-branch push). The
+    #     reusable workflow is also idempotent (skips if an open
+    #     migration issue or PR already exists).
+    if: |
+      needs.check_solution_type.outputs.isSdk == 'false'
+      && github.event_name == 'push'
+      && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    with:
+      assume_legacy: true
+      debug: ${{ inputs.debug }}
+
   CI_SDK:
     uses: ./.github/workflows/Connector Master SDK Workflow.yml
     needs: [check_solution_type, check_oidc]

--- a/.github/workflows/SDK Migration Workflow.yml
+++ b/.github/workflows/SDK Migration Workflow.yml
@@ -213,14 +213,30 @@ jobs:
           2. Convert the solution file from the classic `.sln` format to
              the new XML-based `.slnx` format:
              - Use `dotnet sln <Solution>.sln migrate` (available in
-               .NET SDK 9.0.200+) to generate the `.slnx`. Do not write
-               the XML by hand.
+               .NET SDK 9.0.200+) to generate the `.slnx`. **Do not
+               write or edit the XML by hand** - the format has strict
+               rules that are easy to violate (see below).
              - Delete the old `.sln` after verifying the `.slnx` opens
                correctly and contains the same projects.
              - Update any references to the `.sln` filename (CI scripts,
                docs, `Directory.Build.*`) so they point at the new
                `.slnx` file. The DataMiner connector CI workflows accept
                either format - no changes needed there.
+             - **slnx format rules** (must hold in the final file):
+               - Every solution folder `Path` attribute must start AND
+                 end with `/` (e.g. `Path="/Dlls/"`, not `Path="Dlls"`
+                 or `Path="/Dlls"`). A common failure is
+                 `MSB4025: Solution folder path 'X' must start and end
+                 with '/'`. If you see this, fix the folder paths and
+                 re-verify; do not work around it by hand-editing.
+               - Solution folder entries use `<Folder Path="/Name/" />`,
+                 not `<Folder Name="Name" />`.
+             - **Verify the `.slnx` is well-formed BEFORE opening the
+               PR** by running:
+                 `dotnet sln <Solution>.slnx list`
+               If that command fails, the `.slnx` is broken - re-run
+               `dotnet sln migrate` from the original `.sln` (or restore
+               it from git) instead of trying to patch the XML.
           3. Delete obsolete files (`packages.config`, legacy
              `AssemblyInfo.cs` if redundant, `app.config` if unused).
           4. Run locally to verify:
@@ -247,6 +263,9 @@ jobs:
           - [ ] Every `.csproj` is SDK-style.
           - [ ] The solution has been converted from `.sln` to `.slnx`
                 (via `dotnet sln migrate`) and the old `.sln` is removed.
+          - [ ] `dotnet sln <Solution>.slnx list` succeeds (proves the
+                `.slnx` is well-formed; in particular, all solution
+                folder paths start and end with `/`).
           - [ ] `dotnet build` succeeds.
           - [ ] `<GenerateAssemblyInfo>` is **not** set to `false` (the
                 SDK must generate `AssemblyVersion` etc. so SonarCloud

--- a/.github/workflows/SDK Migration Workflow.yml
+++ b/.github/workflows/SDK Migration Workflow.yml
@@ -42,15 +42,31 @@ on:
         type: boolean
         default: false
 
+      # OIDC parameters (computed by the caller, typically the master
+      # workflow's check_oidc job). When use-oidc is 'true', the assignment
+      # step will log in to Azure and pull `copilot-assign-token` from
+      # Azure Key Vault `kv-master-cicd-secrets` - same pattern as the
+      # other reusable workflows in this repo.
+      oidc-client-id:
+        required: false
+        type: string
+      oidc-tenant-id:
+        required: false
+        type: string
+      oidc-subscription-id:
+        required: false
+        type: string
+      use-oidc:
+        required: false
+        type: string
+        default: 'false'
+
     secrets:
       # Optional user-owned token (fine-grained PAT or OAuth token) used
       # ONLY to assign the created issue to the Copilot coding agent.
-      # The default GITHUB_TOKEN is an App installation token and cannot
-      # perform `replaceActorsForAssignable`, so assignment to Copilot
-      # silently degrades to an unassigned issue without this secret.
-      # Recommended setup: an organization-level secret named
-      # COPILOT_ASSIGN_TOKEN with a fine-grained PAT scoped to
-      # "Issues: Read and write" on the connector repos.
+      # Inside SkylineCommunications the token is pulled from Key Vault
+      # via OIDC instead, so this secret is only relevant for external
+      # callers who don't have OIDC configured.
       copilot_assign_token:
         required: false
 
@@ -103,6 +119,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: read
+      id-token: write       # required for OIDC login to Azure
     steps:
       - uses: actions/checkout@v6
 
@@ -177,7 +194,33 @@ jobs:
                entries with the same versions.
              - Preserve target framework(s) and any DataMiner-specific
                MSBuild properties (e.g. protocol name, version).
-          2. Update the `.sln` if project paths / GUIDs change.
+             - **Do NOT set `<GenerateAssemblyInfo>false</GenerateAssemblyInfo>`.**
+               The SDK must be allowed to generate the assembly-level
+               attributes (`AssemblyVersion`, `AssemblyFileVersion`,
+               `AssemblyTitle`, etc.) from the project properties.
+               Leaving the property at its default `true` is required;
+               otherwise SonarCloud will fail with a missing
+               `AssemblyVersion` attribute after `AssemblyInfo.cs` is
+               deleted. If the legacy project explicitly set this to
+               `false`, drop the line entirely - do not carry it over.
+             - When removing `AssemblyInfo.cs`, migrate any meaningful
+               values it contained (e.g. `AssemblyVersion`,
+               `AssemblyFileVersion`, `AssemblyTitle`, `AssemblyCompany`,
+               `AssemblyProduct`) into the corresponding MSBuild
+               properties (`<Version>`, `<FileVersion>`,
+               `<AssemblyTitle>`, `<Company>`, `<Product>`) in the
+               csproj so the generated attributes match the originals.
+          2. Convert the solution file from the classic `.sln` format to
+             the new XML-based `.slnx` format:
+             - Use `dotnet sln <Solution>.sln migrate` (available in
+               .NET SDK 9.0.200+) to generate the `.slnx`. Do not write
+               the XML by hand.
+             - Delete the old `.sln` after verifying the `.slnx` opens
+               correctly and contains the same projects.
+             - Update any references to the `.sln` filename (CI scripts,
+               docs, `Directory.Build.*`) so they point at the new
+               `.slnx` file. The DataMiner connector CI workflows accept
+               either format - no changes needed there.
           3. Delete obsolete files (`packages.config`, legacy
              `AssemblyInfo.cs` if redundant, `app.config` if unused).
           4. Run locally to verify:
@@ -192,16 +235,22 @@ jobs:
              issues only if the fix is mechanical and obvious.
           5. Open a pull request:
              - Branch name: `chore/sdk-migration`
-             - Title: `chore: migrate to SDK-style csproj`
+             - Title: `chore: migrate to SDK-style csproj and slnx`
              - Label: `sdk-migration`
              - Description: list each project converted, summarize
-               removed files, and paste the validator summary
-               (Critical / Major / Minor / Warning counts).
+               removed files, note the `.sln` → `.slnx` switch, and
+               paste the validator summary (Critical / Major / Minor /
+               Warning counts).
 
           ### Acceptance criteria
 
           - [ ] Every `.csproj` is SDK-style.
+          - [ ] The solution has been converted from `.sln` to `.slnx`
+                (via `dotnet sln migrate`) and the old `.sln` is removed.
           - [ ] `dotnet build` succeeds.
+          - [ ] `<GenerateAssemblyInfo>` is **not** set to `false` (the
+                SDK must generate `AssemblyVersion` etc. so SonarCloud
+                does not flag a missing `AssemblyVersion` attribute).
           - [ ] `dataminer-validator validate` reports 0 Critical /
                 0 Major issues.
           - [ ] The `Connector Master Workflow` run on the PR takes the
@@ -249,7 +298,7 @@ jobs:
           # token, because GitHub does not allow assigning the Copilot
           # coding agent with App installation tokens (the default).
           issue_url=$(gh issue create \
-            --title "chore: migrate to SDK-style csproj" \
+            --title "chore: migrate to SDK-style csproj and slnx" \
             --body-file issue-body.md \
             --label "sdk-migration")
 
@@ -258,20 +307,57 @@ jobs:
           echo "number=$issue_number" >> "$GITHUB_OUTPUT"
           echo "url=$issue_url" >> "$GITHUB_OUTPUT"
 
+      - name: Azure Login (for Key Vault token retrieval)
+        if: steps.existing.outputs.skip != 'true' && inputs.dry_run != true && inputs.use-oidc == 'true'
+        uses: azure/login@v3
+        with:
+          client-id: ${{ inputs.oidc-client-id }}
+          tenant-id: ${{ inputs.oidc-tenant-id }}
+          subscription-id: ${{ inputs.oidc-subscription-id }}
+
+      - name: Retrieve Copilot assignment token from Key Vault
+        if: steps.existing.outputs.skip != 'true' && inputs.dry_run != true && inputs.use-oidc == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Fetching copilot-assign-token from Azure Key Vault..."
+          secret_value=$(az keyvault secret show \
+            --vault-name kv-master-cicd-secrets \
+            --name copilot-assign-token \
+            --query value -o tsv)
+          echo "::add-mask::$secret_value"
+          echo "COPILOT_ASSIGN_TOKEN=$secret_value" >> "$GITHUB_ENV"
+
+      - name: Resolve assignment token (allow secret to override)
+        if: steps.existing.outputs.skip != 'true' && inputs.dry_run != true
+        shell: bash
+        env:
+          USER_PROVIDED: ${{ secrets.copilot_assign_token }}
+        run: |
+          # If the caller explicitly passed a copilot_assign_token secret,
+          # prefer that (covers external users without OIDC, or org
+          # members who want to use their own PAT).
+          if [ -n "$USER_PROVIDED" ]; then
+            echo "::add-mask::$USER_PROVIDED"
+            echo "COPILOT_ASSIGN_TOKEN=$USER_PROVIDED" >> "$GITHUB_ENV"
+            echo "Using copilot_assign_token from caller-provided secret."
+          elif [ -n "${COPILOT_ASSIGN_TOKEN:-}" ]; then
+            echo "Using copilot-assign-token from Azure Key Vault."
+          else
+            echo "::warning::No Copilot assignment token available (no OIDC, no copilot_assign_token secret). The issue will be created unassigned."
+          fi
+
       - name: Assign issue to Copilot coding agent
         if: steps.existing.outputs.skip != 'true' && inputs.dry_run != true
         env:
-          # Prefer the user-owned token if provided; otherwise the default
-          # token is used and the assignment is expected to fail with a
-          # warning (issue remains unassigned but tracked).
-          GH_TOKEN: ${{ secrets.copilot_assign_token || github.token }}
+          GH_TOKEN: ${{ env.COPILOT_ASSIGN_TOKEN || github.token }}
           ASSIGNEE: ${{ inputs.assignee }}
           ISSUE_NUMBER: ${{ steps.create.outputs.number }}
         run: |
           set -euo pipefail
 
-          if [ -z "${{ secrets.copilot_assign_token }}" ]; then
-            echo "::warning::No 'copilot_assign_token' secret provided. The default GITHUB_TOKEN cannot assign the Copilot coding agent. The issue was created unassigned. See README for setup."
+          if [ -z "${COPILOT_ASSIGN_TOKEN:-}" ]; then
+            echo "Skipping assignment - no user-owned token available."
             exit 0
           fi
 

--- a/.github/workflows/SDK Migration Workflow.yml
+++ b/.github/workflows/SDK Migration Workflow.yml
@@ -42,6 +42,18 @@ on:
         type: boolean
         default: false
 
+    secrets:
+      # Optional user-owned token (fine-grained PAT or OAuth token) used
+      # ONLY to assign the created issue to the Copilot coding agent.
+      # The default GITHUB_TOKEN is an App installation token and cannot
+      # perform `replaceActorsForAssignable`, so assignment to Copilot
+      # silently degrades to an unassigned issue without this secret.
+      # Recommended setup: an organization-level secret named
+      # COPILOT_ASSIGN_TOKEN with a fine-grained PAT scoped to
+      # "Issues: Read and write" on the connector repos.
+      copilot_assign_token:
+        required: false
+
 permissions: {}
 
 jobs:
@@ -226,23 +238,43 @@ jobs:
 
       - name: Create migration issue
         if: steps.existing.outputs.skip != 'true' && inputs.dry_run != true
+        id: create
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          # Assignment to the Copilot coding agent: best-effort. If the
-          # assignee cannot be resolved on this repo (e.g. Copilot coding
-          # agent not enabled), fall back to creating the issue without
-          # an assignee so the work item is at least tracked.
-          if ! gh issue create \
-                --title "chore: migrate to SDK-style csproj" \
-                --body-file issue-body.md \
-                --label "sdk-migration" \
-                --assignee "${{ inputs.assignee }}"; then
-            echo "::warning::Could not assign issue to '${{ inputs.assignee }}'. Creating unassigned."
-            gh issue create \
-              --title "chore: migrate to SDK-style csproj" \
-              --body-file issue-body.md \
-              --label "sdk-migration"
+          # Always create the issue first with the default GITHUB_TOKEN.
+          # Assignment is handled in a separate step using a user-owned
+          # token, because GitHub does not allow assigning the Copilot
+          # coding agent with App installation tokens (the default).
+          issue_url=$(gh issue create \
+            --title "chore: migrate to SDK-style csproj" \
+            --body-file issue-body.md \
+            --label "sdk-migration")
+
+          echo "Created issue: $issue_url"
+          issue_number="${issue_url##*/}"
+          echo "number=$issue_number" >> "$GITHUB_OUTPUT"
+          echo "url=$issue_url" >> "$GITHUB_OUTPUT"
+
+      - name: Assign issue to Copilot coding agent
+        if: steps.existing.outputs.skip != 'true' && inputs.dry_run != true
+        env:
+          # Prefer the user-owned token if provided; otherwise the default
+          # token is used and the assignment is expected to fail with a
+          # warning (issue remains unassigned but tracked).
+          GH_TOKEN: ${{ secrets.copilot_assign_token || github.token }}
+          ASSIGNEE: ${{ inputs.assignee }}
+          ISSUE_NUMBER: ${{ steps.create.outputs.number }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${{ secrets.copilot_assign_token }}" ]; then
+            echo "::warning::No 'copilot_assign_token' secret provided. The default GITHUB_TOKEN cannot assign the Copilot coding agent. The issue was created unassigned. See README for setup."
+            exit 0
+          fi
+
+          if ! gh issue edit "$ISSUE_NUMBER" --add-assignee "$ASSIGNEE"; then
+            echo "::warning::Could not assign issue #$ISSUE_NUMBER to '$ASSIGNEE'. The issue remains unassigned but tracked."
           fi

--- a/.github/workflows/SDK Migration Workflow.yml
+++ b/.github/workflows/SDK Migration Workflow.yml
@@ -1,0 +1,248 @@
+name: SDK Migration Workflow
+
+# Reusable workflow that detects legacy-style DataMiner connector solutions
+# and opens a GitHub Issue assigned to the GitHub Copilot coding agent to
+# perform the migration to SDK-style csproj. Copilot then iterates and
+# opens a PR that goes through the regular Connector Master Workflow
+# (which will now take the SDK path) for full validation.
+#
+# Intended trigger in the caller repo: `schedule:` (e.g. weekly) or
+# `workflow_dispatch:`. Do NOT call this from a push/PR trigger - that
+# would create duplicate issues on every push.
+#
+# Required permissions on the caller's job:
+#   contents:      read
+#   issues:        write
+#   pull-requests: read
+
+on:
+  workflow_call:
+    inputs:
+      # When true, the caller asserts that the solution is already known
+      # to be legacy-style (e.g. the master workflow's check_solution_type
+      # job determined isSdk=false). Skips the redundant SDKChecker run.
+      assume_legacy:
+        required: false
+        type: boolean
+        default: false
+      # Optional override of the agent's assignee login. Defaults to the
+      # GitHub Copilot coding agent bot.
+      assignee:
+        required: false
+        type: string
+        default: copilot-swe-agent
+      # When true, the workflow logs what it would do but does not create
+      # an issue. Useful for piloting on a few repos.
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+      debug:
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  detect_legacy:
+    name: Detect legacy csproj
+    if: inputs.assume_legacy != true
+    runs-on: ubuntu-latest
+    outputs:
+      isLegacy: ${{ steps.checker.outputs.isLegacy }}
+    permissions:
+      contents: read
+    steps:
+      - name: Enable long paths
+        run: git config --global core.longpaths true
+
+      - uses: actions/checkout@v6
+
+      - name: Install SDKChecker
+        run: dotnet tool install Skyline.DataMiner.CICD.Tools.SDKChecker --global --version 2.*
+
+      - name: Run SDKChecker
+        id: checker
+        run: |
+          # SDKChecker prints nothing when the solution is already SDK-style.
+          # Any non-empty output means at least one project is still legacy.
+          output="$(SDKChecker --workspace "${{ github.workspace }}" \
+                              --repositoryName "${{ github.repositoryUrl }}" \
+                              --repositoryBranch "${{ github.ref_name }}")"
+          if [ -z "$output" ]; then
+            echo "isLegacy=false" >> "$GITHUB_OUTPUT"
+            echo "Solution is already SDK-style - nothing to do."
+          else
+            echo "isLegacy=true" >> "$GITHUB_OUTPUT"
+            echo "Legacy csproj detected:"
+            echo "$output"
+          fi
+
+  request_migration:
+    name: Request SDK migration
+    needs: detect_legacy
+    # Run when either the caller asserted legacy, or detection confirmed it.
+    if: |
+      always()
+      && (inputs.assume_legacy == true || needs.detect_legacy.outputs.isLegacy == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check for existing migration issue or PR
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Look for an open issue or PR with the migration label/title so
+          # we never create duplicates. Idempotency is critical at fleet
+          # scale - re-running this workflow weekly must be safe.
+          existing_issue=$(gh issue list \
+            --state open \
+            --label "sdk-migration" \
+            --json number,title \
+            --jq 'length')
+
+          existing_pr=$(gh pr list \
+            --state open \
+            --label "sdk-migration" \
+            --json number,title \
+            --jq 'length')
+
+          # Also catch PRs from the conventional branch name even without label
+          branch_pr=$(gh pr list \
+            --state open \
+            --head "chore/sdk-migration" \
+            --json number \
+            --jq 'length')
+
+          if [ "$existing_issue" != "0" ] || [ "$existing_pr" != "0" ] || [ "$branch_pr" != "0" ]; then
+            echo "An open SDK migration issue or PR already exists - skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ensure sdk-migration label exists
+        if: steps.existing.outputs.skip != 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create "sdk-migration" \
+            --description "Tracks migration from legacy to SDK-style csproj" \
+            --color "1f6feb" \
+            2>/dev/null || true
+
+      - name: Write issue body
+        if: steps.existing.outputs.skip != 'true'
+        id: body
+        run: |
+          cat > issue-body.md <<'EOF'
+          ## Task: Migrate this connector solution to SDK-style csproj
+
+          This repository still uses the **legacy** csproj format. As a
+          result, CI uses the `Connector Master Legacy Workflow.yml`
+          pipeline. We are standardizing on the **SDK-style** csproj so
+          that all connectors share the modern `Connector Master SDK
+          Workflow.yml` path (validator, Sonar, packaging).
+
+          ### What to do
+
+          1. Convert every `.csproj` in the solution from legacy format to
+             SDK-style (`<Project Sdk="Microsoft.NET.Sdk">`), following
+             Skyline conventions for DataMiner connectors:
+             - Use `Skyline.DataMiner.Sdk` where appropriate.
+             - Remove items that are now implicit (default `Compile`
+               globs, `AssemblyInfo.cs` content, etc.).
+             - Preserve all `PackageReference` / `ProjectReference`
+               entries with the same versions.
+             - Preserve target framework(s) and any DataMiner-specific
+               MSBuild properties (e.g. protocol name, version).
+          2. Update the `.sln` if project paths / GUIDs change.
+          3. Delete obsolete files (`packages.config`, legacy
+             `AssemblyInfo.cs` if redundant, `app.config` if unused).
+          4. Run locally to verify:
+             - `dotnet restore`
+             - `dotnet build`
+             - `dataminer-validator validate protocol-solution \
+                 --solution-path . \
+                 --output-directory . \
+                 --output-file-name validateResults`
+             Iterate until the validator reports **0 Critical** and
+             **0 Major** issues. Resolve newly surfaced minor/warning
+             issues only if the fix is mechanical and obvious.
+          5. Open a pull request:
+             - Branch name: `chore/sdk-migration`
+             - Title: `chore: migrate to SDK-style csproj`
+             - Label: `sdk-migration`
+             - Description: list each project converted, summarize
+               removed files, and paste the validator summary
+               (Critical / Major / Minor / Warning counts).
+
+          ### Acceptance criteria
+
+          - [ ] Every `.csproj` is SDK-style.
+          - [ ] `dotnet build` succeeds.
+          - [ ] `dataminer-validator validate` reports 0 Critical /
+                0 Major issues.
+          - [ ] The `Connector Master Workflow` run on the PR takes the
+                **SDK** path (i.e. `CI_SDK` runs, `CI_Legacy` is skipped).
+          - [ ] No functional changes to protocol behavior - this is a
+                pure project-format migration.
+
+          ### Out of scope
+
+          - Refactoring QAction logic.
+          - Bumping connector version beyond what the migration requires.
+          - Changing protocol.xml content other than what the SDK
+            structure mandates.
+
+          ---
+
+          *This issue was opened automatically by the
+          `SDK Migration Workflow` reusable workflow. Once a PR is opened
+          and merged, this issue can be closed.*
+          EOF
+
+          if [ "${{ inputs.debug }}" = "true" ]; then
+            echo "----- issue-body.md -----"
+            cat issue-body.md
+            echo "-------------------------"
+          fi
+
+      - name: Create migration issue (dry run)
+        if: steps.existing.outputs.skip != 'true' && inputs.dry_run == true
+        run: |
+          echo "[dry-run] Would create issue 'Migrate to SDK-style csproj' assigned to '${{ inputs.assignee }}'."
+          echo "[dry-run] Body:"
+          cat issue-body.md
+
+      - name: Create migration issue
+        if: steps.existing.outputs.skip != 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Assignment to the Copilot coding agent: best-effort. If the
+          # assignee cannot be resolved on this repo (e.g. Copilot coding
+          # agent not enabled), fall back to creating the issue without
+          # an assignee so the work item is at least tracked.
+          if ! gh issue create \
+                --title "chore: migrate to SDK-style csproj" \
+                --body-file issue-body.md \
+                --label "sdk-migration" \
+                --assignee "${{ inputs.assignee }}"; then
+            echo "::warning::Could not assign issue to '${{ inputs.assignee }}'. Creating unassigned."
+            gh issue create \
+              --title "chore: migrate to SDK-style csproj" \
+              --body-file issue-body.md \
+              --label "sdk-migration"
+          fi

--- a/.github/workflows/SDK Migration Workflow.yml
+++ b/.github/workflows/SDK Migration Workflow.yml
@@ -239,24 +239,48 @@ jobs:
                it from git) instead of trying to patch the XML.
           3. Delete obsolete files (`packages.config`, legacy
              `AssemblyInfo.cs` if redundant, `app.config` if unused).
-          4. Run locally to verify:
-             - `dotnet restore`
-             - `dotnet build`
-             - `dataminer-validator validate protocol-solution \
-                 --solution-path . \
-                 --output-directory . \
-                 --output-file-name validateResults`
+          4. **Mandatory pre-PR validation gate.** Before opening the
+             pull request you MUST run the DataMiner connector
+             validator and confirm it passes. Skipping this step is
+             not acceptable - the PR will be rejected.
+
+             Steps:
+             ```bash
+             # Install the validator if it is not already on PATH
+             dotnet tool install -g Skyline.DataMiner.CICD.Tools.Validator --version 3.*
+
+             dotnet restore
+             dotnet build
+
+             dataminer-validator validate protocol-solution \
+               --solution-path . \
+               --output-directory . \
+               --output-file-name validateResults
+             ```
+
+             Then inspect `validateResults.json`:
+             ```bash
+             jq '{Critical: .CriticalIssueCount, Major: .MajorIssueCount, Minor: .MinorIssueCount, Warning: .WarningIssueCount}' validateResults.json
+             ```
+
              Iterate until the validator reports **0 Critical** and
              **0 Major** issues. Resolve newly surfaced minor/warning
              issues only if the fix is mechanical and obvious.
+
+             You MUST paste the four counts (Critical / Major / Minor /
+             Warning) into the PR description as proof this step was
+             performed. A PR without these numbers is incomplete.
           5. Open a pull request:
              - Branch name: `chore/sdk-migration`
              - Title: `chore: migrate to SDK-style csproj and slnx`
              - Label: `sdk-migration`
-             - Description: list each project converted, summarize
-               removed files, note the `.sln` → `.slnx` switch, and
-               paste the validator summary (Critical / Major / Minor /
-               Warning counts).
+             - Description MUST contain:
+               - The list of each `.csproj` converted.
+               - Summary of removed files.
+               - Note on the `.sln` → `.slnx` switch.
+               - **Validator summary table** with the Critical / Major /
+                 Minor / Warning counts from step 4. Without this the PR
+                 is considered incomplete.
 
           ### Acceptance criteria
 
@@ -270,8 +294,11 @@ jobs:
           - [ ] `<GenerateAssemblyInfo>` is **not** set to `false` (the
                 SDK must generate `AssemblyVersion` etc. so SonarCloud
                 does not flag a missing `AssemblyVersion` attribute).
-          - [ ] `dataminer-validator validate` reports 0 Critical /
-                0 Major issues.
+          - [ ] `dataminer-validator validate protocol-solution` was
+                executed locally and reported **0 Critical / 0 Major**
+                issues. The four issue counts (Critical / Major / Minor
+                / Warning) are pasted in the PR description. **This is
+                non-negotiable; do not open the PR without it.**
           - [ ] The `Connector Master Workflow` run on the PR takes the
                 **SDK** path (i.e. `CI_SDK` runs, `CI_Legacy` is skipped).
           - [ ] No functional changes to protocol behavior - this is a

--- a/README.md
+++ b/README.md
@@ -151,28 +151,32 @@ defense.
 GitHub does **not** allow assigning the Copilot coding agent with the
 default `GITHUB_TOKEN`, because it is a GitHub App installation token
 and the `replaceActorsForAssignable` mutation is restricted to
-user-owned tokens. Without a user token, the issue is still created but
-remains unassigned (you'll see a warning in the workflow log).
+user-owned tokens. The workflow therefore needs a separate token to
+perform the assignment. Without one, the issue is still created and
+labeled — it just remains unassigned (you'll see a warning in the log).
 
-To make assignment work fleet-wide, create one **organization-level
-secret** that the reusable workflow can read via `secrets: inherit`:
+Two ways to provide that token are supported, in this order of
+preference:
 
-| Secret name              | Type                                                                              |
-| ------------------------ | --------------------------------------------------------------------------------- |
-| `COPILOT_ASSIGN_TOKEN`   | Fine-grained PAT (or OAuth token) with **Issues: Read and write** on target repos |
+1. **Azure Key Vault via OIDC (internal SkylineCommunications repos).**
+   The master workflow's `check_oidc` job already produces OIDC
+   parameters. The migration workflow uses them to `azure/login@v3` and
+   pull a secret named **`copilot-assign-token`** from the existing
+   `kv-master-cicd-secrets` Key Vault — same pattern as `azure-token`,
+   `sonar-token`, etc. in the other reusable workflows. Nothing extra
+   is required from caller repos; just keep using `secrets: inherit`
+   when calling the master workflow.
 
-Steps:
+2. **`copilot_assign_token` workflow secret (external callers, or
+   override).** If the caller passes a `copilot_assign_token` secret, it
+   takes precedence over the Key Vault value. Useful for repos outside
+   the SkylineCommunications organization (no OIDC) or for testing with
+   a personal PAT. The PAT must be user-owned and have
+   **Issues: Read and write** on the target repo.
 
-1. Create a fine-grained PAT owned by a service user (not a personal
-   account) with **Issues: Read and write** for the connector repos.
-2. Add it as an organization secret named `COPILOT_ASSIGN_TOKEN` and
-   make it available to the connector repositories.
-3. Ensure the leaf wrapper workflow in each connector repo uses
-   `secrets: inherit` when calling `Connector Master Workflow.yml`
-   (this is already the standard pattern).
-
-If the secret is missing, the workflow degrades gracefully — issues are
-still opened and labeled, just without the Copilot assignee.
+If neither source provides a token, the issue is created unassigned and
+a warning is emitted. Maintainers can then manually assign it to
+Copilot.
 
 ### Standalone use (optional)
 
@@ -193,12 +197,16 @@ When called standalone, omit `assume_legacy` and the workflow will run
 
 ### Inputs
 
-| Input           | Type    | Default              | Description                                                                |
-| --------------- | ------- | -------------------- | -------------------------------------------------------------------------- |
-| `assume_legacy` | boolean | `false`              | Caller asserts the solution is legacy-style; skips the SDKChecker run.     |
-| `assignee`      | string  | `copilot-swe-agent`  | Login of the Copilot coding agent (override only if needed).               |
-| `dry_run`       | boolean | `false`              | Log the planned issue without creating it.                                 |
-| `debug`         | boolean | `false`              | Verbose logging.                                                           |
+| Input                  | Type    | Default              | Description                                                                          |
+| ---------------------- | ------- | -------------------- | ------------------------------------------------------------------------------------ |
+| `assume_legacy`        | boolean | `false`              | Caller asserts the solution is legacy-style; skips the SDKChecker run.               |
+| `assignee`             | string  | `copilot-swe-agent`  | Login of the Copilot coding agent (override only if needed).                         |
+| `dry_run`              | boolean | `false`              | Log the planned issue without creating it.                                           |
+| `debug`                | boolean | `false`              | Verbose logging.                                                                     |
+| `use-oidc`             | string  | `false`              | When `'true'`, log in to Azure and pull `copilot-assign-token` from Key Vault.       |
+| `oidc-client-id`       | string  | —                    | Azure OIDC client id (passed through by the master workflow's `check_oidc` job).     |
+| `oidc-tenant-id`       | string  | —                    | Azure OIDC tenant id.                                                                |
+| `oidc-subscription-id` | string  | —                    | Azure OIDC subscription id.                                                          |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,185 @@
+# \_ReusableWorkflows
+
+Centralized GitHub Actions **reusable workflows** used by 2000+ Skyline
+repositories. Caller repos reference one of the *master* workflows here so
+that build, validation, packaging and publishing logic stays consistent
+across the fleet and can be evolved in a single place.
+
+## Master workflows
+
+| Workflow                                                  | Purpose                                                        |
+| --------------------------------------------------------- | -------------------------------------------------------------- |
+| `Connector Master Workflow.yml`                           | CI/CD for DataMiner connector solutions (SDK and Legacy).      |
+| `Connector Master SDK Workflow.yml`                       | SDK-style connector pipeline (validator, Sonar, packaging).    |
+| `Connector Master Legacy Workflow.yml`                    | Legacy connector pipeline.                                     |
+| `Automation Master Workflow.yml`                          | CI/CD for Automation scripts (SDK and Legacy).                 |
+| `Automation Master SDK Workflow.yml` / `Legacy`           | SDK / Legacy automation pipelines.                             |
+| `NuGet Solution Master Workflow.yml`                      | Build & publish public NuGet packages.                         |
+| `Internal NuGet Solution Master Workflow.yml`             | Build & publish internal NuGet packages.                       |
+| `SRM Function Master Workflow.yml`                        | CI/CD for SRM functions.                                       |
+| `DataMiner App Packages Master Workflow.yml`              | Build & publish DataMiner application packages.                |
+| `Update Catalog Details Workflow.yml`                     | Update Catalog metadata on release.                            |
+| `Test Downstream.yml`                                     | Verifies downstream repos still build against changes here.    |
+| `SDK Migration Workflow.yml`                              | Detects legacy csproj and asks Copilot to open a migration PR. |
+| `Master Workflow.yml`                                     | Top-level dispatcher.                                          |
+
+---
+
+## AI Review (advisory) — opt-in
+
+The `Connector Master Workflow.yml` can post an **AI-generated, advisory
+summary** of the DataMiner connector validator output as a comment on the
+pull request. It is implemented as a separate reusable workflow
+(`AI Review Workflow.yml`) and uses [GitHub Models] via
+`actions/ai-inference@v2`, so no extra API key is required.
+
+[GitHub Models]: https://docs.github.com/en/github-models
+
+### What it does
+
+1. Downloads the `validatorResults` artifact produced by the connector
+   pipeline (`validateResults.json` + `compareResults.json`).
+2. Compresses the JSON (top issues only, useful fields only) into a prompt.
+3. Asks a model to produce a short Markdown review grouped by severity,
+   with file:line and concrete fixes, and a dedicated **Breaking changes**
+   section for compare-validator findings.
+4. Posts the review as a PR comment and writes it to the job step summary.
+
+### Guarantees
+
+- **Advisory only.** The job has `continue-on-error: true` and runs *after*
+  the existing quality gate. It can never block a merge.
+- **Opt-in per repo.** Disabled by default; nothing changes for existing
+  callers.
+- **Least privilege.** The AI job declares its own minimal `permissions:`
+  (`contents: read`, `pull-requests: write`, `models: read`,
+  `actions: read`) instead of inheriting the workflow-level `write-all`.
+- **PR-scoped.** Only runs on `pull_request` events.
+
+### How to opt in
+
+In your repo's wrapper workflow, set `enable_ai_review: true` when calling
+the connector master workflow:
+
+```yaml
+jobs:
+  CI:
+    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Connector Master Workflow.yml@main
+    with:
+      sonarCloudProjectName: my-sonar-project
+      enable_ai_review: true            # turn on the AI review
+      # ai_review_model: openai/gpt-4o-mini   # optional override
+    secrets: inherit
+```
+
+### Inputs
+
+| Input              | Type    | Default               | Description                                  |
+| ------------------ | ------- | --------------------- | -------------------------------------------- |
+| `enable_ai_review` | boolean | `false`               | Enable the advisory AI review job.           |
+| `ai_review_model`  | string  | `openai/gpt-4o-mini`  | GitHub Models model id used for the review.  |
+
+### Scope
+
+The AI Review is currently only wired into the **Connector** master
+workflow, because the connector pipeline is the only one that produces
+validator output. Other masters (Automation, NuGet, SRM Function, App
+Packages) do not have an equivalent validator, so the AI review is not
+applicable there. Future AI-assisted workflows for those pipelines (e.g.
+test-failure triage, release-notes generation) will be added as separate
+reusable workflows when needed.
+
+---
+
+## SDK Migration (agentic) — automatic on legacy repos
+
+`SDK Migration Workflow.yml` is an **agentic** reusable workflow that
+helps move older connector repos off the legacy csproj format and onto
+the SDK-style csproj that the modern `Connector Master SDK Workflow.yml`
+pipeline expects.
+
+It is **wired into `Connector Master Workflow.yml`** and triggers
+automatically when the legacy path is taken — no per-repo opt-in needed.
+This way, developers working on an old repo organically discover a
+migration PR the next time CI runs on the default branch.
+
+### What it does
+
+1. The connector master workflow's `check_solution_type` job runs
+   `SDKChecker`. If `isSdk=false`, the `CI_Legacy` job runs as before.
+2. In parallel, `Request_SDK_Migration` calls this workflow with
+   `assume_legacy: true`.
+3. The workflow checks for an existing open issue/PR with the
+   `sdk-migration` label, or an open PR from `chore/sdk-migration`. If
+   one exists, it skips.
+4. Otherwise it opens a GitHub Issue with a detailed migration brief and
+   **assigns it to the GitHub Copilot coding agent**.
+5. Copilot iterates on the conversion, runs `dotnet build` and
+   `dataminer-validator` in its own sandbox, and opens a PR titled
+   `chore: migrate to SDK-style csproj`.
+6. That PR runs through the normal `Connector Master Workflow.yml` —
+   which now takes the **SDK** path — so the same quality gate that
+   protects human PRs also protects this agent-generated PR.
+
+### Trigger gating
+
+The migration request only fires when **all** of the following are true:
+
+- The solution is legacy-style (`isSdk == 'false'`).
+- The event is a `push` (not a `pull_request` or tag).
+- The push is to the **default branch** of the repo.
+
+This avoids creating duplicate issues from PR runs or feature-branch
+pushes. The reusable workflow is also idempotent as a second line of
+defense.
+
+### Guarantees
+
+- **No direct writes to `main`.** The agent always opens a PR.
+- **Idempotent.** Skips if an open issue or PR with the `sdk-migration`
+  label, or a PR from `chore/sdk-migration`, already exists.
+- **Quality-gated.** The agent's PR goes through the same SDK pipeline
+  that protects human PRs.
+- **Least privilege.** Job-scoped `permissions:` (`contents: read`,
+  `issues: write`, `pull-requests: read`).
+- **Falls back gracefully.** If the Copilot coding agent isn't enabled on
+  the repo, the issue is still created (unassigned) so the work is
+  tracked.
+
+### Standalone use (optional)
+
+The workflow can also be called directly (e.g. on a schedule across the
+fleet) if you want a one-shot sweep instead of waiting for each repo's
+next push to its default branch:
+
+```yaml
+jobs:
+  Migration:
+    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/SDK Migration Workflow.yml@main
+    with:
+      dry_run: true   # recommended for the initial pilot
+```
+
+When called standalone, omit `assume_legacy` and the workflow will run
+`SDKChecker` itself.
+
+### Inputs
+
+| Input           | Type    | Default              | Description                                                                |
+| --------------- | ------- | -------------------- | -------------------------------------------------------------------------- |
+| `assume_legacy` | boolean | `false`              | Caller asserts the solution is legacy-style; skips the SDKChecker run.     |
+| `assignee`      | string  | `copilot-swe-agent`  | Login of the Copilot coding agent (override only if needed).               |
+| `dry_run`       | boolean | `false`              | Log the planned issue without creating it.                                 |
+| `debug`         | boolean | `false`              | Verbose logging.                                                           |
+
+---
+
+## Cost & rate limits
+
+The SDK Migration workflow consumes Copilot coding agent capacity. At
+2000+ repos:
+
+- Trigger gating (push to default branch only, idempotency check) keeps
+  volume bounded.
+- Review Copilot agent throughput before assuming fleet-wide rollout is
+  smooth.

--- a/README.md
+++ b/README.md
@@ -142,9 +142,37 @@ defense.
   that protects human PRs.
 - **Least privilege.** Job-scoped `permissions:` (`contents: read`,
   `issues: write`, `pull-requests: read`).
-- **Falls back gracefully.** If the Copilot coding agent isn't enabled on
-  the repo, the issue is still created (unassigned) so the work is
-  tracked.
+- **Falls back gracefully.** If the Copilot coding agent assignment
+  fails (e.g. no user token, agent not enabled on the repo), the issue
+  is still created (unassigned) so the work is tracked.
+
+### Required setup — Copilot assignment token
+
+GitHub does **not** allow assigning the Copilot coding agent with the
+default `GITHUB_TOKEN`, because it is a GitHub App installation token
+and the `replaceActorsForAssignable` mutation is restricted to
+user-owned tokens. Without a user token, the issue is still created but
+remains unassigned (you'll see a warning in the workflow log).
+
+To make assignment work fleet-wide, create one **organization-level
+secret** that the reusable workflow can read via `secrets: inherit`:
+
+| Secret name              | Type                                                                              |
+| ------------------------ | --------------------------------------------------------------------------------- |
+| `COPILOT_ASSIGN_TOKEN`   | Fine-grained PAT (or OAuth token) with **Issues: Read and write** on target repos |
+
+Steps:
+
+1. Create a fine-grained PAT owned by a service user (not a personal
+   account) with **Issues: Read and write** for the connector repos.
+2. Add it as an organization secret named `COPILOT_ASSIGN_TOKEN` and
+   make it available to the connector repositories.
+3. Ensure the leaf wrapper workflow in each connector repo uses
+   `secrets: inherit` when calling `Connector Master Workflow.yml`
+   (this is already the standard pattern).
+
+If the secret is missing, the workflow degrades gracefully — issues are
+still opened and labeled, just without the Copilot assignee.
 
 ### Standalone use (optional)
 


### PR DESCRIPTION
Introduce a reusable SDK Migration workflow and wire it into the Connector Master workflow. Adds .github/workflows/SDK Migration Workflow.yml which detects legacy-style csproj (via SDKChecker), checks for existing migration issues/PRs, and opens an idempotent sdk-migration issue (assigning the Copilot coding agent where possible) or performs a dry-run. Update Connector Master Workflow to call the migration workflow when a legacy solution is detected on pushes to the repository default branch. Also add README.md documenting master workflows, the AI review feature, and the SDK migration flow, triggers, and guarantees.