### PR TITLE
Add GitHub and Azure NuGet source actions

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -36,6 +36,8 @@ Usage examples in each action README are sourced from the master workflows in
 | `guard-trigger` | Blocks unsupported `pull_request_target` executions. | [guard-trigger/README.md](guard-trigger/README.md) |
 | `resolve-oidc` | Resolves Azure OIDC values and exposes `use-oidc`. | [resolve-oidc/README.md](resolve-oidc/README.md) |
 | `load-secrets` | Loads Key Vault secrets and applies caller overrides. | [load-secrets/README.md](load-secrets/README.md) |
+| `add-github-nuget-source` | Registers a GitHub Packages NuGet source. | [add-github-nuget-source/README.md](add-github-nuget-source/README.md) |
+| `add-azure-nuget-source` | Registers an Azure DevOps NuGet source by URL. | [add-azure-nuget-source/README.md](add-azure-nuget-source/README.md) |
 | `setup-nuget-sources` | Registers GitHub and optional Skyline NuGet feeds. | [setup-nuget-sources/README.md](setup-nuget-sources/README.md) |
 | `validate-inputs` | Validates mandatory Sonar/DataMiner inputs based on context. | [validate-inputs/README.md](validate-inputs/README.md) |
 | `update-global-json-sdks` | Rewrites managed `msbuild-sdks` versions in `global.json`. | [update-global-json-sdks/README.md](update-global-json-sdks/README.md) |

--- a/.github/actions/add-azure-nuget-source/README.md
+++ b/.github/actions/add-azure-nuget-source/README.md
@@ -1,0 +1,53 @@
+# add-azure-nuget-source
+
+Registers an Azure DevOps NuGet source by URL.
+
+The action is idempotent: re-running updates an existing source with the same name in place.
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `url` | yes | - | Azure DevOps NuGet feed URL. |
+| `token` | yes | - | Token used to authenticate against the Azure DevOps NuGet feed. |
+| `name` | no | `""` | Optional NuGet source name. Defaults to a name derived from `url`. |
+
+## Outputs
+
+No outputs.
+
+## Required Permissions
+
+No additional `GITHUB_TOKEN` permissions are required beyond reading the repository contents:
+
+```yaml
+permissions:
+  contents: read
+```
+
+The token must be allowed to read packages from the target Azure DevOps feed.
+
+## Used by
+
+- [Test composite actions.yml](../../workflows/Test%20composite%20actions.yml)
+
+## Usage
+
+### Basic
+
+```yaml
+- uses: SkylineCommunications/_ReusableWorkflows/.github/actions/add-azure-nuget-source@main
+  with:
+    url: https://pkgs.dev.azure.com/organization/project/_packaging/feed/nuget/v3/index.json
+    token: ${{ secrets.AZURE_TOKEN }}
+```
+
+### Custom source name
+
+```yaml
+- uses: SkylineCommunications/_ReusableWorkflows/.github/actions/add-azure-nuget-source@main
+  with:
+    url: https://pkgs.dev.azure.com/skyline-cloud/Cloud_NuGets/_packaging/CloudNuGet/nuget/v3/index.json
+    token: ${{ secrets.AZURE_TOKEN }}
+    name: CloudNuGets
+```

--- a/.github/actions/add-azure-nuget-source/action.yml
+++ b/.github/actions/add-azure-nuget-source/action.yml
@@ -1,0 +1,27 @@
+name: Add Azure NuGet source
+description: >
+  Registers an Azure DevOps NuGet source by URL.
+  Existing sources with the same name are updated in place so the step is idempotent.
+
+inputs:
+  url:
+    description: Azure DevOps NuGet feed URL.
+    required: true
+  token:
+    description: Token used to authenticate against the Azure DevOps NuGet feed.
+    required: true
+  name:
+    description: Optional NuGet source name. Defaults to a name derived from `url`.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Add Azure NuGet source
+      shell: pwsh
+      env:
+        URL: ${{ inputs.url }}
+        TOKEN: ${{ inputs.token }}
+        SOURCE_NAME: ${{ inputs.name }}
+      run: ${{ github.action_path }}/add-azure-nuget-source.ps1

--- a/.github/actions/add-azure-nuget-source/add-azure-nuget-source.ps1
+++ b/.github/actions/add-azure-nuget-source/add-azure-nuget-source.ps1
@@ -1,0 +1,48 @@
+# Registers an Azure DevOps NuGet source by URL.
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-NuGetSourceName {
+    param(
+        [Parameter(Mandatory)] [string] $Value
+    )
+
+    $sourceName = $Value.Trim() -replace '^https?://', ''
+    $sourceName = $sourceName -replace '/nuget/v3/index\.json$', ''
+    $sourceName = $sourceName -replace '[^A-Za-z0-9_.-]+', '-'
+    $sourceName = $sourceName.Trim('-')
+
+    if ([string]::IsNullOrWhiteSpace($sourceName)) {
+        return 'azure-nuget-source'
+    }
+
+    return "azure-$sourceName"
+}
+
+$url = ([string] $env:URL).Trim()
+$token = ([string] $env:TOKEN).Trim()
+$sourceName = ([string] $env:SOURCE_NAME).Trim()
+
+if ([string]::IsNullOrWhiteSpace($url)) {
+    throw 'Input url is required.'
+}
+
+if ([string]::IsNullOrWhiteSpace($token)) {
+    throw 'Input token is required.'
+}
+
+if ([string]::IsNullOrWhiteSpace($sourceName)) {
+    $sourceName = ConvertTo-NuGetSourceName -Value $url
+}
+
+$username = 'az'
+
+Write-Host "Checking source $sourceName..."
+$existing = dotnet nuget list source | Select-String -Pattern $sourceName -SimpleMatch
+
+if ($existing) {
+    Write-Host "Updating existing source $sourceName."
+    dotnet nuget update source $sourceName --source $url --username $username -p $token --store-password-in-clear-text
+} else {
+    Write-Host "Adding new source $sourceName."
+    dotnet nuget add source $url --name $sourceName --username $username -p $token --store-password-in-clear-text
+}

--- a/.github/actions/add-github-nuget-source/README.md
+++ b/.github/actions/add-github-nuget-source/README.md
@@ -1,0 +1,54 @@
+# add-github-nuget-source
+
+Registers a GitHub Packages NuGet source for a GitHub organization.
+
+The action is idempotent: re-running updates an existing source with the same name in place.
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `organization` | yes | - | GitHub organization or owner that hosts the NuGet feed. |
+| `token` | yes | - | Token used to authenticate against the GitHub Packages feed. |
+| `name` | no | `""` | Optional NuGet source name. Defaults to a name derived from `organization`. |
+
+## Outputs
+
+No outputs.
+
+## Required Permissions
+
+When using `GITHUB_TOKEN`, the caller job needs package read access:
+
+```yaml
+permissions:
+  contents: read
+  packages: read
+```
+
+The token must be allowed to read packages from the target GitHub organization.
+
+## Used by
+
+- [Test composite actions.yml](../../workflows/Test%20composite%20actions.yml)
+
+## Usage
+
+### Basic
+
+```yaml
+- uses: SkylineCommunications/_ReusableWorkflows/.github/actions/add-github-nuget-source@main
+  with:
+    organization: SkylineCommunications
+    token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Custom source name
+
+```yaml
+- uses: SkylineCommunications/_ReusableWorkflows/.github/actions/add-github-nuget-source@main
+  with:
+    organization: SkylineCommunications
+    token: ${{ secrets.GITHUB_TOKEN }}
+    name: PrivateGitHubNugets
+```

--- a/.github/actions/add-github-nuget-source/action.yml
+++ b/.github/actions/add-github-nuget-source/action.yml
@@ -1,0 +1,27 @@
+name: Add GitHub NuGet source
+description: >
+  Registers a GitHub Packages NuGet source for the specified organization.
+  Existing sources with the same name are updated in place so the step is idempotent.
+
+inputs:
+  organization:
+    description: GitHub organization or owner that hosts the NuGet feed.
+    required: true
+  token:
+    description: Token used to authenticate against the GitHub Packages feed.
+    required: true
+  name:
+    description: Optional NuGet source name. Defaults to a name derived from `organization`.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Add GitHub NuGet source
+      shell: pwsh
+      env:
+        ORGANIZATION: ${{ inputs.organization }}
+        TOKEN: ${{ inputs.token }}
+        SOURCE_NAME: ${{ inputs.name }}
+      run: ${{ github.action_path }}/add-github-nuget-source.ps1

--- a/.github/actions/add-github-nuget-source/add-github-nuget-source.ps1
+++ b/.github/actions/add-github-nuget-source/add-github-nuget-source.ps1
@@ -1,0 +1,47 @@
+# Registers a GitHub Packages NuGet source for a GitHub organization.
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-NuGetSourceName {
+    param(
+        [Parameter(Mandatory)] [string] $Value
+    )
+
+    $sourceName = $Value.Trim() -replace '[^A-Za-z0-9_.-]+', '-'
+    $sourceName = $sourceName.Trim('-')
+
+    if ([string]::IsNullOrWhiteSpace($sourceName)) {
+        return 'github-nuget-source'
+    }
+
+    return "github-$sourceName"
+}
+
+$organization = ([string] $env:ORGANIZATION).Trim()
+$token = ([string] $env:TOKEN).Trim()
+$sourceName = ([string] $env:SOURCE_NAME).Trim()
+
+if ([string]::IsNullOrWhiteSpace($organization)) {
+    throw 'Input organization is required.'
+}
+
+if ([string]::IsNullOrWhiteSpace($token)) {
+    throw 'Input token is required.'
+}
+
+if ([string]::IsNullOrWhiteSpace($sourceName)) {
+    $sourceName = ConvertTo-NuGetSourceName -Value $organization
+}
+
+$url = "https://nuget.pkg.github.com/$organization/index.json"
+$username = 'USERNAME'
+
+Write-Host "Checking source $sourceName..."
+$existing = dotnet nuget list source | Select-String -Pattern $sourceName -SimpleMatch
+
+if ($existing) {
+    Write-Host "Updating existing source $sourceName."
+    dotnet nuget update source $sourceName --source $url --username $username -p $token --store-password-in-clear-text
+} else {
+    Write-Host "Adding new source $sourceName."
+    dotnet nuget add source $url --name $sourceName --username $username -p $token --store-password-in-clear-text
+}

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -130,6 +130,62 @@ jobs:
           count=$(dotnet nuget list source | grep -c PrivateGitHubNugets)
           test "$count" -eq 1
 
+  add-github-nuget-source:
+    name: add-github-nuget-source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Invoke composite
+        uses: ./.github/actions/add-github-nuget-source
+        with:
+          organization: ExampleOrganization
+          token: fake-token
+          name: TestGitHubNuGets
+
+      - name: Assert source registered
+        run: dotnet nuget list source | grep -q TestGitHubNuGets
+
+      - name: Re-invoke (idempotency check)
+        uses: ./.github/actions/add-github-nuget-source
+        with:
+          organization: ExampleOrganization
+          token: fake-token
+          name: TestGitHubNuGets
+
+      - name: Assert still exactly one entry
+        run: |
+          count=$(dotnet nuget list source | grep -c TestGitHubNuGets)
+          test "$count" -eq 1
+
+  add-azure-nuget-source:
+    name: add-azure-nuget-source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Invoke composite
+        uses: ./.github/actions/add-azure-nuget-source
+        with:
+          url: https://pkgs.dev.azure.com/example/project/_packaging/feed/nuget/v3/index.json
+          token: fake-token
+          name: TestAzureNuGets
+
+      - name: Assert source registered
+        run: dotnet nuget list source | grep -q TestAzureNuGets
+
+      - name: Re-invoke (idempotency check)
+        uses: ./.github/actions/add-azure-nuget-source
+        with:
+          url: https://pkgs.dev.azure.com/example/project/_packaging/feed/nuget/v3/index.json
+          token: fake-token
+          name: TestAzureNuGets
+
+      - name: Assert still exactly one entry
+        run: |
+          count=$(dotnet nuget list source | grep -c TestAzureNuGets)
+          test "$count" -eq 1
+
   validate-inputs:
     name: validate-inputs
     runs-on: ubuntu-latest


### PR DESCRIPTION
Introduce two new composite actions to register NuGet sources:

- .github/actions/add-github-nuget-source: action.yml, README and PowerShell implementation to add/update a GitHub Packages NuGet source (organization, token, optional name).
- .github/actions/add-azure-nuget-source: action.yml, README and PowerShell implementation to add/update an Azure DevOps NuGet source by URL (url, token, optional name).

Both actions are idempotent (update existing source in place). Also update .github/actions/README.md to list the new actions and extend the Test composite actions workflow to include jobs that validate registration and idempotency for each action.