### PR TITLE
Add Parse RN Task Table composite action

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -49,6 +49,7 @@ Usage examples in each action README are sourced from the master workflows in
 | `detect-test-runner` | Detects MTP or VSTest mode from `global.json`. | [detect-test-runner/README.md](detect-test-runner/README.md) |
 | `run-unit-tests` | Runs unit tests for all test projects in a solution. | [run-unit-tests/README.md](run-unit-tests/README.md) |
 | `unit-tests` | Wrapper combining detect + run unit test actions. | [unit-tests/README.md](unit-tests/README.md) |
+| `parse-rn-task-table` | Parses and validates the mandatory PR RN/Task table and renders the sticky-comment summary. | [parse-rn-task-table/README.md](parse-rn-task-table/README.md) |
 | `quality-gate-summary` | Aggregates unit-test / SonarCloud / Validator outcomes, renders a Job Summary + sticky PR comment, and fails the job on any failed sub-gate. | [quality-gate-summary/README.md](quality-gate-summary/README.md) |
 
 ## Referencing from a reusable workflow in this repo

--- a/.github/actions/parse-rn-task-table/README.md
+++ b/.github/actions/parse-rn-task-table/README.md
@@ -1,0 +1,56 @@
+# parse-rn-task-table
+
+Parses the RN/Task table in a pull request description and validates the mandatory DxM release administration.
+
+The action finds the markdown table with `RN` and `Task` header columns, parses comma-separated ids per row, normalizes ids to upper-case, validates the id format, resolves the `Change-Type` label, and writes a markdown summary for the `skyline-rn-task` sticky PR comment.
+
+## Inputs
+
+| Input | Required | Description |
+| --- | --- | --- |
+| `pr-body` | yes | Pull request description markdown. |
+| `actor` | yes | Pull request author login. Only `dependabot[bot]` may omit task ids. |
+| `labels-json` | yes | JSON array of PR label names. Used to resolve `Change-Type`. |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `status` | `passed` or `failed`. |
+| `rns` | JSON array of all normalized RN ids. |
+| `pairs` | JSON array of row groupings, each shaped as `{ "rns": [...], "tasks": [...] }`. |
+| `change-type` | `Patch`, `Minor`, or `Major`. No `Change-Type:*` label resolves to `Patch`. |
+| `comment-file` | Absolute path to the rendered markdown summary. |
+
+## Rules
+
+- RN ids must match `RN` followed by digits, for example `RN12`.
+- Task ids must match `DCP` followed by digits, for example `DCP35`.
+- Multiple ids in one cell are comma-separated and treated as one linked grouping.
+- Regular PRs require at least one RN and at least one task, and every RN row must have a task.
+- `dependabot[bot]` PRs require an RN only; a human on a `dependabot/*` branch is not exempt.
+- At most one `Change-Type:*` label is allowed. Valid values are `Patch`, `Minor`, and `Major`.
+
+## Usage
+
+```yaml
+- name: Parse RN/Task table
+  id: rn-task
+  uses: SkylineCommunications/_ReusableWorkflows/.github/actions/parse-rn-task-table@main
+  with:
+    pr-body: ${{ github.event.pull_request.body }}
+    actor: ${{ github.event.pull_request.user.login }}
+    labels-json: ${{ toJson(github.event.pull_request.labels.*.name) }}
+```
+
+The parser does not fail the step for validation errors. It emits `status=failed` so the caller can still post the sticky comment before enforcing the gate.
+
+## Tests
+
+The 16-case PR validation corpus runs through:
+
+```powershell
+pwsh .github/actions/parse-rn-task-table/test.ps1
+```
+
+The same command is wired into [Test composite actions.yml](../../workflows/Test%20composite%20actions.yml).

--- a/.github/actions/parse-rn-task-table/action.yml
+++ b/.github/actions/parse-rn-task-table/action.yml
@@ -1,0 +1,46 @@
+name: Parse RN Task Table
+description: >
+  Parses the RN/Task markdown table from a pull request body, validates RN and
+  DCP task ids, resolves the Change-Type label, and renders a markdown summary
+  for a sticky PR comment.
+
+inputs:
+  pr-body:
+    description: The pull request description markdown.
+    required: true
+  actor:
+    description: The pull request author login. Used for the dependabot[bot] task exception.
+    required: true
+  labels-json:
+    description: JSON array of pull request label names. Used to resolve Change-Type.
+    required: true
+
+outputs:
+  status:
+    description: Validation result, either passed or failed.
+    value: ${{ steps.parse.outputs.status }}
+  rns:
+    description: JSON array of all normalized RN ids found in the table.
+    value: ${{ steps.parse.outputs.rns }}
+  pairs:
+    description: JSON array of row groupings, each with rns and tasks arrays.
+    value: ${{ steps.parse.outputs.pairs }}
+  change-type:
+    description: Resolved change type, one of Patch, Minor, or Major.
+    value: ${{ steps.parse.outputs.change-type }}
+  comment-file:
+    description: Absolute path to the rendered markdown summary file.
+    value: ${{ steps.parse.outputs.comment-file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Parse RN/Task table
+      id: parse
+      shell: pwsh
+      env:
+        PR_BODY: ${{ inputs.pr-body }}
+        ACTOR: ${{ inputs.actor }}
+        LABELS_JSON: ${{ inputs.labels-json }}
+        COMMENT_HEADER: skyline-rn-task
+      run: '& "$env:GITHUB_ACTION_PATH/parse-rn-task-table.ps1"'

--- a/.github/actions/parse-rn-task-table/parse-rn-task-table.ps1
+++ b/.github/actions/parse-rn-task-table/parse-rn-task-table.ps1
@@ -1,0 +1,332 @@
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT)) {
+    throw 'GITHUB_OUTPUT must be set.'
+}
+
+if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+    throw 'GITHUB_WORKSPACE must be set.'
+}
+
+$prBody = if ($null -ne $env:PR_BODY) { $env:PR_BODY } else { '' }
+$actor = if ($null -ne $env:ACTOR) { $env:ACTOR } else { '' }
+$labelsJson = if ($null -ne $env:LABELS_JSON) { $env:LABELS_JSON } else { '[]' }
+$commentHeader = if ($null -ne $env:COMMENT_HEADER) { $env:COMMENT_HEADER } else { 'skyline-rn-task' }
+
+$errors = [System.Collections.Generic.List[string]]::new()
+$allRns = [System.Collections.Generic.List[string]]::new()
+$seenRns = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$pairs = [System.Collections.Generic.List[object]]::new()
+$changeType = 'Patch'
+$tableFound = $false
+$dataRowCount = 0
+
+function Add-ValidationError {
+    param([Parameter(Mandatory)][string]$Message)
+
+    $script:errors.Add($Message)
+}
+
+function ConvertTo-TrimmedValue {
+    param([AllowNull()][string]$Value)
+
+    if ($null -eq $Value) {
+        return ''
+    }
+
+    return $Value.Replace("`r", '').Trim()
+}
+
+function Get-MarkdownCells {
+    param([Parameter(Mandatory)][string]$Row)
+
+    $trimmedRow = ConvertTo-TrimmedValue -Value $Row
+    if ($trimmedRow.StartsWith('|', [System.StringComparison]::Ordinal)) {
+        $trimmedRow = $trimmedRow.Substring(1)
+    }
+
+    if ($trimmedRow.EndsWith('|', [System.StringComparison]::Ordinal)) {
+        $trimmedRow = $trimmedRow.Substring(0, $trimmedRow.Length - 1)
+    }
+
+    $cells = [System.Text.RegularExpressions.Regex]::Split($trimmedRow, '\|')
+    return @($cells | ForEach-Object { ConvertTo-TrimmedValue -Value $_ })
+}
+
+function Get-NormalizedHeader {
+    param([AllowNull()][string]$Value)
+
+    $trimmedValue = ConvertTo-TrimmedValue -Value $Value
+    return ([System.Text.RegularExpressions.Regex]::Replace($trimmedValue, '\s+', '')).ToLowerInvariant()
+}
+
+function Test-SeparatorCell {
+    param([AllowNull()][string]$Value)
+
+    $trimmedValue = ConvertTo-TrimmedValue -Value $Value
+    $normalizedValue = [System.Text.RegularExpressions.Regex]::Replace($trimmedValue.Replace(':', ''), '\s+', '')
+    return $normalizedValue -match '^-+$'
+}
+
+function ConvertTo-JsonArray {
+    param([AllowNull()][object[]]$Value)
+
+    $array = if ($null -eq $Value) { @() } else { @($Value) }
+    return ConvertTo-Json -InputObject ([object[]]$array) -Compress -Depth 10
+}
+
+function Get-ParsedIdCell {
+    param(
+        [AllowNull()][string]$RawCell,
+        [Parameter(Mandatory)][string]$Kind,
+        [Parameter(Mandatory)][int]$RowNumber,
+        [Parameter(Mandatory)][string]$Pattern,
+        [Parameter(Mandatory)][string]$Expected
+    )
+
+    $parsedIds = [System.Collections.Generic.List[string]]::new()
+    $trimmedCell = ConvertTo-TrimmedValue -Value $RawCell
+    if ([string]::IsNullOrWhiteSpace($trimmedCell)) {
+        return @()
+    }
+
+    $tokens = [System.Text.RegularExpressions.Regex]::Split($trimmedCell, ',')
+    foreach ($rawToken in $tokens) {
+        $token = ConvertTo-TrimmedValue -Value $rawToken
+        if ([string]::IsNullOrWhiteSpace($token)) {
+            Add-ValidationError -Message "Row ${RowNumber}: empty ${Kind} id in '${trimmedCell}'."
+        } elseif ($token -match $Pattern) {
+            $parsedIds.Add($token.ToUpperInvariant())
+        } else {
+            Add-ValidationError -Message "Row ${RowNumber}: malformed ${Kind} id '${token}' (expected ${Expected})."
+        }
+    }
+
+    return @($parsedIds.ToArray())
+}
+
+function Resolve-ChangeType {
+    $labels = @()
+    try {
+        $parsedLabels = ConvertFrom-Json -InputObject $script:labelsJson -NoEnumerate -ErrorAction Stop
+        if ($null -eq $parsedLabels) {
+            $labels = @()
+        } elseif ($parsedLabels -is [System.Array]) {
+            $labels = @($parsedLabels)
+        } else {
+            Add-ValidationError -Message 'labels-json must be a JSON array of label names.'
+            return
+        }
+    } catch {
+        Add-ValidationError -Message 'labels-json must be a JSON array of label names.'
+        return
+    }
+
+    $changeLabels = @($labels | Where-Object { $_ -is [string] -and $_ -match '^Change-Type:' })
+    if ($changeLabels.Count -gt 1) {
+        Add-ValidationError -Message "At most one Change-Type:* label is allowed; found $($changeLabels.Count)."
+        return
+    }
+
+    if ($changeLabels.Count -eq 0) {
+        $script:changeType = 'Patch'
+        return
+    }
+
+    $suffix = ($changeLabels[0] -split ':', 2)[1]
+    switch -Regex ($suffix) {
+        '^(?i)patch$' { $script:changeType = 'Patch'; break }
+        '^(?i)minor$' { $script:changeType = 'Minor'; break }
+        '^(?i)major$' { $script:changeType = 'Major'; break }
+        default { Add-ValidationError -Message "Unsupported Change-Type label '$($changeLabels[0])' (expected Change-Type:Patch, Change-Type:Minor, or Change-Type:Major)." }
+    }
+}
+
+function Add-Pair {
+    param(
+        [Parameter(Mandatory)][string[]]$Rns,
+        [AllowEmptyCollection()][string[]]$Tasks
+    )
+
+    $taskArray = @($Tasks)
+    $script:pairs.Add([PSCustomObject]@{
+        rns = [string[]]@($Rns)
+        tasks = [string[]]$taskArray
+    })
+}
+
+function Add-Rn {
+    param([Parameter(Mandatory)][string[]]$Rns)
+
+    foreach ($rn in $Rns) {
+        if ($script:seenRns.Add($rn)) {
+            $script:allRns.Add($rn)
+        }
+    }
+}
+
+function Parse-RnTaskTable {
+    $lines = [System.Text.RegularExpressions.Regex]::Split($script:prBody, "`r?`n")
+    $rnColumn = -1
+    $taskColumn = -1
+    $dataStart = -1
+
+    for ($index = 0; $index -lt $lines.Count; $index++) {
+        if (-not $lines[$index].Contains('|')) {
+            continue
+        }
+
+        $cells = Get-MarkdownCells -Row $lines[$index]
+        $rnColumn = -1
+        $taskColumn = -1
+
+        for ($column = 0; $column -lt $cells.Count; $column++) {
+            switch (Get-NormalizedHeader -Value $cells[$column]) {
+                'rn' { $rnColumn = $column }
+                'task' { $taskColumn = $column }
+            }
+        }
+
+        if ($rnColumn -ge 0 -and $taskColumn -ge 0 -and ($index + 1) -lt $lines.Count) {
+            $separatorCells = Get-MarkdownCells -Row $lines[$index + 1]
+            if ($separatorCells.Count -gt $rnColumn -and $separatorCells.Count -gt $taskColumn -and
+                (Test-SeparatorCell -Value $separatorCells[$rnColumn]) -and
+                (Test-SeparatorCell -Value $separatorCells[$taskColumn])) {
+                $script:tableFound = $true
+                $dataStart = $index + 2
+                break
+            }
+        }
+    }
+
+    if (-not $script:tableFound) {
+        Add-ValidationError -Message 'Could not find an RN/Task markdown table with header columns RN and Task.'
+        return
+    }
+
+    for ($index = $dataStart; $index -lt $lines.Count; $index++) {
+        if (-not $lines[$index].Contains('|')) {
+            break
+        }
+
+        $cells = Get-MarkdownCells -Row $lines[$index]
+        if ($cells.Count -le $rnColumn -or $cells.Count -le $taskColumn) {
+            break
+        }
+
+        if ((Test-SeparatorCell -Value $cells[$rnColumn]) -and (Test-SeparatorCell -Value $cells[$taskColumn])) {
+            continue
+        }
+
+        $script:dataRowCount++
+        $rowNumber = $script:dataRowCount
+        $rowRns = [string[]]@(Get-ParsedIdCell -RawCell $cells[$rnColumn] -Kind 'RN' -RowNumber $rowNumber -Pattern '^RN\d+$' -Expected 'RN followed by digits' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        $rowTasks = [string[]]@(Get-ParsedIdCell -RawCell $cells[$taskColumn] -Kind 'task' -RowNumber $rowNumber -Pattern '^DCP\d+$' -Expected 'DCP followed by digits' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
+        if ($rowRns.Count -eq 0 -and $rowTasks.Count -eq 0) {
+            Add-ValidationError -Message "Row ${rowNumber}: at least one RN id is required."
+        }
+
+        if ($rowRns.Count -eq 0 -and $rowTasks.Count -gt 0) {
+            Add-ValidationError -Message "Row ${rowNumber}: task ids require at least one linked RN id."
+        }
+
+        if ($script:actor -ne 'dependabot[bot]' -and $rowRns.Count -gt 0 -and $rowTasks.Count -eq 0) {
+            Add-ValidationError -Message "Row ${rowNumber}: task id is required for non-Dependabot PRs."
+        }
+
+        if ($rowRns.Count -gt 0) {
+            Add-Rn -Rns $rowRns
+            Add-Pair -Rns $rowRns -Tasks $rowTasks
+        }
+    }
+
+    if ($script:dataRowCount -eq 0) {
+        Add-ValidationError -Message 'The RN/Task table has no data rows.'
+    }
+}
+
+function Write-ValidationComment {
+    param(
+        [Parameter(Mandatory)][string]$Status,
+        [AllowEmptyCollection()][string[]]$Rns
+    )
+
+    $commentFile = Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath 'rn-task-validation-comment.md'
+    $headingStatus = if ($Status -eq 'failed') { 'Failed' } else { 'Passed' }
+    $dependabotMode = if ($script:actor -eq 'dependabot[bot]') { 'yes' } else { 'no' }
+    $content = [System.Collections.Generic.List[string]]::new()
+
+    $content.Add("<!-- ${script:commentHeader} -->")
+    $content.Add("## PR RN/Task Validation: ${headingStatus}")
+    $content.Add('')
+    $content.Add('| Item | Value |')
+    $content.Add('| --- | --- |')
+    $content.Add("| Status | ${Status} |")
+    $content.Add("| Change-Type | ${script:changeType} |")
+    $content.Add("| Dependabot RN-only mode | ${dependabotMode} |")
+    $content.Add('')
+
+    if ($script:pairs.Count -gt 0) {
+        $content.Add('| RN(s) | Task(s) |')
+        $content.Add('| --- | --- |')
+        foreach ($pair in $script:pairs) {
+            $rnsValue = [string]::Join(', ', @($pair.rns))
+            $tasksValue = if (@($pair.tasks).Count -eq 0) { '-' } else { [string]::Join(', ', @($pair.tasks)) }
+            $content.Add("| ${rnsValue} | ${tasksValue} |")
+        }
+        $content.Add('')
+    }
+
+    if ($script:errors.Count -gt 0) {
+        $content.Add('Validation errors:')
+        foreach ($validationError in $script:errors) {
+            $content.Add("- ${validationError}")
+        }
+        $content.Add('')
+    }
+
+    if ($Rns.Count -gt 0) {
+        $content.Add("Parsed RN ids: $([string]::Join(', ', $Rns))")
+    }
+
+    Set-Content -Path $commentFile -Value $content -Encoding utf8
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+        Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $content -Encoding utf8
+    }
+
+    return $commentFile
+}
+
+Resolve-ChangeType
+Parse-RnTaskTable
+
+$rns = [string[]]@($allRns.ToArray())
+$rnsJson = ConvertTo-JsonArray -Value $rns
+$pairsJson = ConvertTo-Json -InputObject ([object[]]$pairs.ToArray()) -Compress -Depth 10
+
+if ($tableFound) {
+    if ($rns.Count -eq 0) {
+        Add-ValidationError -Message 'At least one RN id is required.'
+    }
+
+    $taskCount = 0
+    foreach ($pair in $pairs) {
+        $taskCount += @($pair.tasks).Count
+    }
+
+    if ($actor -ne 'dependabot[bot]' -and $taskCount -eq 0) {
+        Add-ValidationError -Message 'At least one task id is required for non-Dependabot PRs.'
+    }
+}
+
+$status = if ($errors.Count -gt 0) { 'failed' } else { 'passed' }
+$commentFile = Write-ValidationComment -Status $status -Rns $rns
+
+@(
+    "status=${status}"
+    "rns=${rnsJson}"
+    "pairs=${pairsJson}"
+    "change-type=${changeType}"
+    "comment-file=${commentFile}"
+) | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8

--- a/.github/actions/parse-rn-task-table/test.ps1
+++ b/.github/actions/parse-rn-task-table/test.ps1
@@ -1,0 +1,129 @@
+$ErrorActionPreference = 'Stop'
+
+$actionDirectory = Split-Path -Parent $PSCommandPath
+$temporaryDirectory = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "parse-rn-task-table-$([System.Guid]::NewGuid())"
+New-Item -Path $temporaryDirectory -ItemType Directory | Out-Null
+
+function Get-OutputValue {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    $prefix = "${Name}="
+    $line = Get-Content -Path $Path | Where-Object { $_.StartsWith($prefix, [System.StringComparison]::Ordinal) } | Select-Object -Last 1
+    if ($null -eq $line) {
+        return ''
+    }
+
+    return $line.Substring($prefix.Length)
+}
+
+function Assert-Equal {
+    param(
+        [AllowNull()][object]$Actual,
+        [AllowNull()][object]$Expected,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    if ($Actual -ne $Expected) {
+        throw "${Label}: expected '${Expected}', got '${Actual}'."
+    }
+}
+
+function Assert-JsonEqual {
+    param(
+        [Parameter(Mandatory)][string]$Actual,
+        [Parameter(Mandatory)][string]$Expected,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    $actualCanonical = ConvertTo-Json -InputObject (ConvertFrom-Json -InputObject $Actual -NoEnumerate) -Compress -Depth 10
+    $expectedCanonical = ConvertTo-Json -InputObject (ConvertFrom-Json -InputObject $Expected -NoEnumerate) -Compress -Depth 10
+    if ($actualCanonical -ne $expectedCanonical) {
+        throw "${Label}: expected ${expectedCanonical}, got ${actualCanonical}."
+    }
+}
+
+function Invoke-ParserCase {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Body,
+        [Parameter(Mandatory)][string]$Actor,
+        [Parameter(Mandatory)][string]$LabelsJson,
+        [Parameter(Mandatory)][string]$ExpectedStatus,
+        [Parameter(Mandatory)][string]$ExpectedChangeType,
+        [Parameter(Mandatory)][string]$ExpectedPairCount,
+        [Parameter(Mandatory)][string]$ExpectedRnsJson,
+        [Parameter(Mandatory)][string]$ExpectedPairsJson
+    )
+
+    $caseDirectoryName = $Name -replace '[^A-Za-z0-9]', '_'
+    $caseDirectory = Join-Path -Path $temporaryDirectory -ChildPath $caseDirectoryName
+    $workspaceDirectory = Join-Path -Path $caseDirectory -ChildPath 'workspace'
+    New-Item -Path $workspaceDirectory -ItemType Directory -Force | Out-Null
+    $outputFile = Join-Path -Path $caseDirectory -ChildPath 'outputs.txt'
+    $summaryFile = Join-Path -Path $caseDirectory -ChildPath 'summary.md'
+
+    $env:PR_BODY = $Body
+    $env:ACTOR = $Actor
+    $env:LABELS_JSON = $LabelsJson
+    $env:COMMENT_HEADER = 'skyline-rn-task'
+    $env:GITHUB_OUTPUT = $outputFile
+    $env:GITHUB_STEP_SUMMARY = $summaryFile
+    $env:GITHUB_WORKSPACE = $workspaceDirectory
+
+    & (Join-Path -Path $actionDirectory -ChildPath 'parse-rn-task-table.ps1')
+
+    $status = Get-OutputValue -Name 'status' -Path $outputFile
+    $changeType = Get-OutputValue -Name 'change-type' -Path $outputFile
+    $rns = Get-OutputValue -Name 'rns' -Path $outputFile
+    $pairs = Get-OutputValue -Name 'pairs' -Path $outputFile
+    $commentFile = Get-OutputValue -Name 'comment-file' -Path $outputFile
+
+    Assert-Equal -Actual $status -Expected $ExpectedStatus -Label "${Name} status"
+
+    if ($ExpectedChangeType -ne '-') {
+        Assert-Equal -Actual $changeType -Expected $ExpectedChangeType -Label "${Name} change-type"
+    }
+
+    if ($ExpectedPairCount -ne '-') {
+        $pairCount = @((ConvertFrom-Json -InputObject $pairs -NoEnumerate)).Count
+        Assert-Equal -Actual $pairCount -Expected ([int]$ExpectedPairCount) -Label "${Name} pair count"
+    }
+
+    if ($ExpectedRnsJson -ne '-') {
+        Assert-JsonEqual -Actual $rns -Expected $ExpectedRnsJson -Label "${Name} rns"
+    }
+
+    if ($ExpectedPairsJson -ne '-') {
+        Assert-JsonEqual -Actual $pairs -Expected $ExpectedPairsJson -Label "${Name} pairs"
+    }
+
+    if (-not (Test-Path -Path $commentFile -PathType Leaf)) {
+        throw "${Name}: expected comment file '${commentFile}' to exist."
+    }
+}
+
+try {
+    Invoke-ParserCase -Name '01 happy path' -Body "| RN | Task |`n| --- | --- |`n| RN12 | DCP35 |" -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'passed' -ExpectedChangeType 'Patch' -ExpectedPairCount '1' -ExpectedRnsJson '["RN12"]' -ExpectedPairsJson '[{"rns":["RN12"],"tasks":["DCP35"]}]'
+    Invoke-ParserCase -Name '02 grouped ids in one row' -Body "| RN | Task |`n| --- | --- |`n| RN12, RN13 | DCP35, DCP66 |" -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'passed' -ExpectedChangeType 'Patch' -ExpectedPairCount '1' -ExpectedRnsJson '["RN12","RN13"]' -ExpectedPairsJson '[{"rns":["RN12","RN13"],"tasks":["DCP35","DCP66"]}]'
+    Invoke-ParserCase -Name '03 multiple rows' -Body "| RN | Task |`n| --- | --- |`n| RN12 | DCP35 |`n| RN13 | DCP66 |" -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'passed' -ExpectedChangeType 'Patch' -ExpectedPairCount '2' -ExpectedRnsJson '["RN12","RN13"]' -ExpectedPairsJson '[{"rns":["RN12"],"tasks":["DCP35"]},{"rns":["RN13"],"tasks":["DCP66"]}]'
+    Invoke-ParserCase -Name '04 missing task regular' -Body "| RN | Task |`n| --- | --- |`n| RN12 | |" -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'failed' -ExpectedChangeType '-' -ExpectedPairCount '-' -ExpectedRnsJson '-' -ExpectedPairsJson '-'
+    Invoke-ParserCase -Name '05 task without rn' -Body "| RN | Task |`n| --- | --- |`n| | DCP35 |" -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'failed' -ExpectedChangeType '-' -ExpectedPairCount '-' -ExpectedRnsJson '-' -ExpectedPairsJson '-'
+    Invoke-ParserCase -Name '06 no table at all' -Body 'This pull request has no release note administration.' -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'failed' -ExpectedChangeType '-' -ExpectedPairCount '-' -ExpectedRnsJson '-' -ExpectedPairsJson '-'
+    Invoke-ParserCase -Name '07 header separator only' -Body "| RN | Task |`n| --- | --- |" -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'failed' -ExpectedChangeType '-' -ExpectedPairCount '-' -ExpectedRnsJson '-' -ExpectedPairsJson '-'
+    Invoke-ParserCase -Name '08 malformed rn' -Body "| RN | Task |`n| --- | --- |`n| R12 | DCP35 |" -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'failed' -ExpectedChangeType '-' -ExpectedPairCount '-' -ExpectedRnsJson '-' -ExpectedPairsJson '-'
+    Invoke-ParserCase -Name '09 malformed task' -Body "| RN | Task |`n| --- | --- |`n| RN12 | DCP-35 |" -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'failed' -ExpectedChangeType '-' -ExpectedPairCount '-' -ExpectedRnsJson '-' -ExpectedPairsJson '-'
+    Invoke-ParserCase -Name '10 dependabot rn only' -Body "| RN | Task |`n| --- | --- |`n| RN12 | |" -Actor 'dependabot[bot]' -LabelsJson '[]' -ExpectedStatus 'passed' -ExpectedChangeType 'Patch' -ExpectedPairCount '1' -ExpectedRnsJson '["RN12"]' -ExpectedPairsJson '[{"rns":["RN12"],"tasks":[]}]'
+    Invoke-ParserCase -Name '11 dependabot branch human actor' -Body "| RN | Task |`n| --- | --- |`n| RN12 | |" -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'failed' -ExpectedChangeType '-' -ExpectedPairCount '-' -ExpectedRnsJson '-' -ExpectedPairsJson '-'
+    Invoke-ParserCase -Name '12 one change type label' -Body "| RN | Task |`n| --- | --- |`n| RN12 | DCP35 |" -Actor 'human' -LabelsJson '["Change-Type:Minor"]' -ExpectedStatus 'passed' -ExpectedChangeType 'Minor' -ExpectedPairCount '1' -ExpectedRnsJson '["RN12"]' -ExpectedPairsJson '-'
+    Invoke-ParserCase -Name '13 two change type labels' -Body "| RN | Task |`n| --- | --- |`n| RN12 | DCP35 |" -Actor 'human' -LabelsJson '["Change-Type:Minor","Change-Type:Major"]' -ExpectedStatus 'failed' -ExpectedChangeType '-' -ExpectedPairCount '-' -ExpectedRnsJson '-' -ExpectedPairsJson '-'
+    Invoke-ParserCase -Name '14 no change type label' -Body "| RN | Task |`n| --- | --- |`n| RN12 | DCP35 |" -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'passed' -ExpectedChangeType 'Patch' -ExpectedPairCount '1' -ExpectedRnsJson '["RN12"]' -ExpectedPairsJson '-'
+    Invoke-ParserCase -Name '15 case insensitive' -Body "| rn | task |`n| --- | --- |`n| rn12 | dcp35 |" -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'passed' -ExpectedChangeType 'Patch' -ExpectedPairCount '1' -ExpectedRnsJson '["RN12"]' -ExpectedPairsJson '[{"rns":["RN12"],"tasks":["DCP35"]}]'
+    Invoke-ParserCase -Name '16 surrounding prose other tables' -Body "Intro text.`n`n| Name | Value |`n| --- | --- |`n| Noise | Table |`n`n| RN | Task |`n| --- | --- |`n| RN12 | DCP35 |`n`nFooter text." -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'passed' -ExpectedChangeType 'Patch' -ExpectedPairCount '1' -ExpectedRnsJson '["RN12"]' -ExpectedPairsJson '[{"rns":["RN12"],"tasks":["DCP35"]}]'
+
+    Write-Output 'All parse-rn-task-table cases passed.'
+} finally {
+    Remove-Item -Path $temporaryDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -593,6 +593,42 @@ jobs:
           token: ${{ secrets.SONAR_TOKEN }}
           repository: ${{ github.repository }}
 
+  parse-rn-task-table:
+    name: parse-rn-task-table
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run 16-case parser corpus
+        shell: pwsh
+        run: ./.github/actions/parse-rn-task-table/test.ps1
+
+      - name: Invoke composite smoke test
+        id: rn-task
+        uses: ./.github/actions/parse-rn-task-table
+        with:
+          pr-body: |
+            | RN | Task |
+            | --- | --- |
+            | RN12 | DCP35 |
+          actor: human
+          labels-json: '["Change-Type:Major"]'
+
+      - name: Assert composite outputs
+        env:
+          STATUS: ${{ steps.rn-task.outputs.status }}
+          CHANGE_TYPE: ${{ steps.rn-task.outputs.change-type }}
+          RNS: ${{ steps.rn-task.outputs.rns }}
+          PAIRS: ${{ steps.rn-task.outputs.pairs }}
+        shell: pwsh
+        run: |
+          if ($env:STATUS -ne 'passed') { throw "Expected status passed, got '$env:STATUS'." }
+          if ($env:CHANGE_TYPE -ne 'Major') { throw "Expected change-type Major, got '$env:CHANGE_TYPE'." }
+          $rns = ConvertTo-Json -InputObject (ConvertFrom-Json -InputObject $env:RNS -NoEnumerate) -Compress -Depth 10
+          $pairs = ConvertTo-Json -InputObject (ConvertFrom-Json -InputObject $env:PAIRS -NoEnumerate) -Compress -Depth 10
+          if ($rns -ne '["RN12"]') { throw "Unexpected RN output: $rns" }
+          if ($pairs -ne '[{"rns":["RN12"],"tasks":["DCP35"]}]') { throw "Unexpected pairs output: $pairs" }
+
   quality-gate-summary:
     name: quality-gate-summary
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request introduces a new composite GitHub Action, `parse-rn-task-table`, designed to parse and validate the mandatory RN/Task table in pull request descriptions. The action ensures proper release note (RN) and task administration, resolves the `Change-Type` label, and generates a markdown summary for sticky PR comments. The implementation includes robust validation, normalization, and comprehensive test coverage.

**New Action: RN/Task Table Parsing and Validation**

* Added a new composite action `parse-rn-task-table` that parses the RN/Task markdown table from PR bodies, validates RN and DCP task IDs, resolves the `Change-Type` label, and outputs a markdown summary for sticky PR comments. The action supports both regular and Dependabot PRs with tailored validation rules. (.github/actions/README.md, .github/actions/parse-rn-task-table/action.yml, .github/actions/parse-rn-task-table/README.md) [[1]](diffhunk://#diff-52d6b7f655d938f43fd7629a638b5183e3fcd1c3d302b3d32479aac06fdacb84R52) [[2]](diffhunk://#diff-ed4e4adcafe64426ffc0b50cafbeaf1bcd447b3b8c2adc4ebf3800ca0221d1d3R1-R46) [[3]](diffhunk://#diff-48c7218c7fc7dccd66db1ae99fb7248c59b288c468353200a370209ee5a873d5R1-R56)

**Implementation Details**

* Implemented the parser logic in PowerShell (`parse-rn-task-table.ps1`), including:
  - Extraction and normalization of RN and DCP IDs.
  - Validation of table structure, ID formats, and required fields.
  - Resolution of the `Change-Type` label from PR labels.
  - Generation of a detailed markdown validation summary for both sticky comments and job summaries.
  - Output of structured results and validation status for use in subsequent workflow steps. (.github/actions/parse-rn-task-table/parse-rn-task-table.ps1)

**Testing**

* Added a comprehensive PowerShell test script (`test.ps1`) that runs 16 validation scenarios, covering edge cases such as missing IDs, malformed tables, label handling, and case insensitivity. The test ensures the parser's correctness and robustness. (.github/actions/parse-rn-task-table/test.ps1)