### PR TITLE
Add Playwright Docker ACR Workflow

### DIFF
--- a/.github/workflows/Playwright Docker ACR Workflow.yml
+++ b/.github/workflows/Playwright Docker ACR Workflow.yml
@@ -1,0 +1,81 @@
+name: Playwright Docker ACR Workflow
+
+on:
+  workflow_call:
+    inputs:
+      project-path:
+        required: true
+        type: string
+        description: 'Path to the LiveServiceTesting project folder (e.g. MyApp.LiveServiceTesting)'
+      image-name:
+        required: true
+        type: string
+        description: 'ACR image name without registry (e.g. myapp-tests)'
+      dockerfile-path:
+        required: false
+        type: string
+        default: 'Dockerfile'
+        description: 'Path to Dockerfile relative to repository root'
+      dotnet-version:
+        required: false
+        type: string
+        default: '8.x'
+        description: '.NET SDK version to use'
+    secrets:
+      ACR_REGISTRY:
+        required: true
+        description: 'Azure Container Registry login server (e.g. myregistry.azurecr.io)'
+      ACR_USERNAME:
+        required: true
+        description: 'Azure Container Registry username'
+      ACR_PASSWORD:
+        required: true
+        description: 'Azure Container Registry password'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+
+      - name: Add Skyline NuGet feed
+        run: |
+          dotnet nuget add source "https://nuget.pkg.github.com/SkylineCommunications/index.json" \
+            --name github \
+            --username ${{ github.actor }} \
+            --password ${{ secrets.GITHUB_TOKEN }} \
+            --store-password-in-clear-text
+
+      - name: Publish test project
+        run: |
+          dotnet publish ${{ inputs.project-path }}/${{ inputs.project-path }}.csproj \
+            -c Release -o ./publish/tests
+
+      - name: Log in to ACR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.ACR_REGISTRY }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ inputs.dockerfile-path }}
+          push: true
+          tags: |
+            ${{ secrets.ACR_REGISTRY }}/${{ inputs.image-name }}:latest
+            ${{ secrets.ACR_REGISTRY }}/${{ inputs.image-name }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ across the fleet and can be evolved in a single place.
 | `Connector Master Legacy Workflow.yml`                    | Legacy connector pipeline.                                                    |
 | `Automation Master Workflow.yml`                          | CI/CD for Automation scripts (SDK and Legacy).                                |
 | `Automation Master SDK Workflow.yml` / `Legacy`           | SDK / Legacy automation pipelines.                                            |
+| `Playwright Docker ACR Workflow.yml`                      | Build and push Playwright .NET test projects to Azure Container Registry.     |
 | `NuGet Solution Master Workflow.yml`                      | *(deprecated)* Thin redirect to `Master Workflow.yml` for public NuGet.       |
 | `Internal NuGet Solution Master Workflow.yml`             | *(deprecated)* Thin redirect to `Master Workflow.yml` for internal NuGet.     |
 | `DataMiner App Packages Master Workflow.yml`              | *(deprecated)* Thin redirect to `Master Workflow.yml` for app packages.       |


### PR DESCRIPTION
- New reusable workflow for building and pushing Playwright .NET test projects to Azure Container Registry
- Includes .NET SDK setup, NuGet feed configuration, Docker build and push with caching
- Updated README.md to document the new workflow in master workflows table