### PR TITLE
Add compute-next-version GitHub Action

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -44,6 +44,7 @@ Usage examples in each action README are sourced from the master workflows in
 | `validate-inputs` | Validates mandatory Sonar/DataMiner inputs based on context. | [validate-inputs/README.md](validate-inputs/README.md) |
 | `update-global-json-sdks` | Rewrites managed `msbuild-sdks` versions in `global.json`. | [update-global-json-sdks/README.md](update-global-json-sdks/README.md) |
 | `apply-catalog-identifiers` | Rewrites manifest `id:` fields from mapping input. | [apply-catalog-identifiers/README.md](apply-catalog-identifiers/README.md) |
+| `compute-next-version` | Computes the next SemVer version from the latest final tag + Change-Type bump. | [compute-next-version/README.md](compute-next-version/README.md) |
 | `apply-source-code-url` | Fills empty `source_code_url:` fields in catalog manifests. | [apply-source-code-url/README.md](apply-source-code-url/README.md) |
 | `sonarcloud-status` | Checks SonarCloud project status and emits analysis flag. | [sonarcloud-status/README.md](sonarcloud-status/README.md) |
 | `detect-test-runner` | Detects MTP or VSTest mode from `global.json`. | [detect-test-runner/README.md](detect-test-runner/README.md) |

--- a/.github/actions/compute-next-version/README.md
+++ b/.github/actions/compute-next-version/README.md
@@ -1,0 +1,55 @@
+# compute-next-version
+
+Computes the next SemVer version from the latest **final** git tag and a `Change-Type` bump.
+
+The action reads the repository tags, selects the highest `X.Y.Z` tag that has **no** pre-release
+suffix, applies the requested `Major` / `Minor` / `Patch` bump, and (in `prerelease` mode) appends a
+suffix. Pre-release tags are ignored when picking the base, so repeated pre-releases on a branch keep
+bumping from the same final version.
+
+## Inputs
+
+| Input | Required | Description |
+| --- | --- | --- |
+| `change-type` | no | The bump to apply: `Patch`, `Minor`, or `Major`. Empty resolves to `Patch`. |
+| `mode` | no | `release` (bare version) or `prerelease` (suffix appended). Defaults to `release`. |
+| `suffix` | no | Pre-release suffix body (e.g. `dev-myfeature.42`). Used only when `mode` is `prerelease`. |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `version` | The computed version, e.g. `1.4.0` or `1.4.0-dev-myfeature.42`. |
+| `latest-tag` | The latest final tag the bump was computed from, or empty when none exists. |
+
+## Rules
+
+- The base is the highest final tag matching `X.Y.Z` (an optional leading `v` is tolerated).
+- Pre-release tags (anything containing `-`) are ignored when selecting the base.
+- When no final tag exists the base is `0.0.0`, so a `Patch` bump yields `0.0.1`.
+- `Major` → `X+1.0.0`, `Minor` → `X.Y+1.0`, `Patch` → `X.Y.Z+1`.
+- `suffix` is ignored in `release` mode.
+
+## Usage
+
+```yaml
+- name: Compute next version
+  id: version
+  uses: SkylineCommunications/_ReusableWorkflows/.github/actions/compute-next-version@main
+  with:
+    change-type: ${{ steps.rn-task.outputs.change-type }}
+    mode: prerelease
+    suffix: dev-myfeature.42
+```
+
+The checkout that precedes this action must fetch tags (`fetch-depth: 0`) so the base tag can be
+resolved.
+
+## Tests
+
+`test.ps1` runs the bump corpus offline by injecting a tag list via the `TAGS_OVERRIDE` environment
+variable (so no git repository or network is required):
+
+```pwsh
+pwsh -NoProfile -File ./test.ps1
+```

--- a/.github/actions/compute-next-version/action.yml
+++ b/.github/actions/compute-next-version/action.yml
@@ -1,0 +1,40 @@
+name: Compute next version
+description: >
+  Computes the next SemVer version from the latest final git tag and a
+  Change-Type bump. Pre-release tags are ignored when selecting the base
+  tag, so repeated pre-releases keep bumping from the same final version.
+  In prerelease mode the provided suffix is appended.
+
+inputs:
+  change-type:
+    description: The SemVer bump to apply, one of Patch, Minor, or Major. Defaults to Patch when empty.
+    required: false
+    default: Patch
+  mode:
+    description: Either release (bare version) or prerelease (suffix appended). Defaults to release.
+    required: false
+    default: release
+  suffix:
+    description: The pre-release suffix body (e.g. dev-myfeature.42). Used only when mode is prerelease.
+    required: false
+    default: ""
+
+outputs:
+  version:
+    description: The computed version, e.g. 1.4.0 or 1.4.0-dev-myfeature.42.
+    value: ${{ steps.compute.outputs.version }}
+  latest-tag:
+    description: The latest final tag the bump was computed from, or empty when no final tag exists.
+    value: ${{ steps.compute.outputs.latest-tag }}
+
+runs:
+  using: composite
+  steps:
+    - name: Compute next version
+      id: compute
+      shell: pwsh
+      env:
+        CHANGE_TYPE: ${{ inputs.change-type }}
+        MODE: ${{ inputs.mode }}
+        SUFFIX: ${{ inputs.suffix }}
+      run: '& "$env:GITHUB_ACTION_PATH/compute-next-version.ps1"'

--- a/.github/actions/compute-next-version/compute-next-version.ps1
+++ b/.github/actions/compute-next-version/compute-next-version.ps1
@@ -1,0 +1,86 @@
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT)) {
+    throw 'GITHUB_OUTPUT must be set.'
+}
+
+$changeTypeRaw = if ([string]::IsNullOrWhiteSpace($env:CHANGE_TYPE)) { 'Patch' } else { $env:CHANGE_TYPE.Trim() }
+$mode = if ([string]::IsNullOrWhiteSpace($env:MODE)) { 'release' } else { $env:MODE.Trim().ToLowerInvariant() }
+$suffix = if ($null -eq $env:SUFFIX) { '' } else { $env:SUFFIX.Trim() }
+
+switch -Regex ($changeTypeRaw) {
+    '^(?i)patch$' { $changeType = 'Patch' }
+    '^(?i)minor$' { $changeType = 'Minor' }
+    '^(?i)major$' { $changeType = 'Major' }
+    default { throw "Unsupported change-type '$changeTypeRaw' (expected Patch, Minor, or Major)." }
+}
+
+if ($mode -ne 'release' -and $mode -ne 'prerelease') {
+    throw "Unsupported mode '$mode' (expected release or prerelease)."
+}
+
+# TAGS_OVERRIDE (newline-separated) lets the unit tests inject a tag corpus without a git
+# repository. When it is unset the tags are read from the checked-out repository instead.
+function Get-Tags {
+    if ($null -ne $env:TAGS_OVERRIDE) {
+        return @([System.Text.RegularExpressions.Regex]::Split($env:TAGS_OVERRIDE, "`r?`n") |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+
+    git fetch --tags --force --quiet 2>$null | Out-Null
+    $tags = git tag --list 2>$null
+    if ($null -eq $tags) {
+        return @()
+    }
+
+    return @($tags | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+# The latest FINAL tag is the highest X.Y.Z with no pre-release suffix. An optional leading
+# 'v' is tolerated, but pre-release tags (anything containing '-') are ignored on purpose.
+$finalPattern = '^v?(\d+)\.(\d+)\.(\d+)$'
+$latestTag = ''
+$latestVersion = $null
+
+foreach ($tag in (Get-Tags)) {
+    $candidate = $tag.Trim()
+    $match = [regex]::Match($candidate, $finalPattern)
+    if (-not $match.Success) {
+        continue
+    }
+
+    $version = [version]::new([int]$match.Groups[1].Value, [int]$match.Groups[2].Value, [int]$match.Groups[3].Value)
+    if ($null -eq $latestVersion -or $version -gt $latestVersion) {
+        $latestVersion = $version
+        $latestTag = $candidate
+    }
+}
+
+if ($null -eq $latestVersion) {
+    $major = 0
+    $minor = 0
+    $patch = 0
+} else {
+    $major = $latestVersion.Major
+    $minor = $latestVersion.Minor
+    $patch = $latestVersion.Build
+}
+
+switch ($changeType) {
+    'Major' { $major += 1; $minor = 0; $patch = 0 }
+    'Minor' { $minor += 1; $patch = 0 }
+    'Patch' { $patch += 1 }
+}
+
+$computed = "$major.$minor.$patch"
+if ($mode -eq 'prerelease' -and -not [string]::IsNullOrWhiteSpace($suffix)) {
+    $computed = "$computed-$suffix"
+}
+
+$baseDescription = if ([string]::IsNullOrWhiteSpace($latestTag)) { '<none>' } else { $latestTag }
+Write-Host "Computed version '$computed' (base final tag: $baseDescription, change-type: $changeType, mode: $mode)."
+
+@(
+    "version=$computed"
+    "latest-tag=$latestTag"
+) | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8

--- a/.github/actions/compute-next-version/test.ps1
+++ b/.github/actions/compute-next-version/test.ps1
@@ -1,0 +1,101 @@
+$ErrorActionPreference = 'Stop'
+
+$actionDirectory = Split-Path -Parent $PSCommandPath
+$scriptPath = Join-Path -Path $actionDirectory -ChildPath 'compute-next-version.ps1'
+$temporaryDirectory = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "compute-next-version-$([System.Guid]::NewGuid())"
+New-Item -Path $temporaryDirectory -ItemType Directory | Out-Null
+
+function Get-OutputValue {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    $prefix = "${Name}="
+    $line = Get-Content -Path $Path | Where-Object { $_.StartsWith($prefix, [System.StringComparison]::Ordinal) } | Select-Object -Last 1
+    if ($null -eq $line) {
+        return ''
+    }
+
+    return $line.Substring($prefix.Length)
+}
+
+function Assert-Equal {
+    param(
+        [AllowNull()][object]$Actual,
+        [AllowNull()][object]$Expected,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    if ($Actual -ne $Expected) {
+        throw "${Label}: expected '${Expected}', got '${Actual}'."
+    }
+}
+
+$failures = 0
+
+function Invoke-Case {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [AllowEmptyCollection()][string[]]$Tags,
+        [AllowEmptyString()][string]$ChangeType,
+        [Parameter(Mandatory)][string]$Mode,
+        [AllowEmptyString()][string]$Suffix,
+        [Parameter(Mandatory)][string]$ExpectedVersion,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$ExpectedLatestTag
+    )
+
+    $outputFile = Join-Path -Path $script:temporaryDirectory -ChildPath "$([System.Guid]::NewGuid()).txt"
+    New-Item -Path $outputFile -ItemType File | Out-Null
+
+    $env:GITHUB_OUTPUT = $outputFile
+    $env:TAGS_OVERRIDE = ($Tags -join "`n")
+    $env:CHANGE_TYPE = $ChangeType
+    $env:MODE = $Mode
+    $env:SUFFIX = $Suffix
+
+    try {
+        & $script:scriptPath | Out-Null
+
+        $version = Get-OutputValue -Name 'version' -Path $outputFile
+        $latestTag = Get-OutputValue -Name 'latest-tag' -Path $outputFile
+
+        Assert-Equal -Actual $version -Expected $ExpectedVersion -Label "${Name} (version)"
+        Assert-Equal -Actual $latestTag -Expected $ExpectedLatestTag -Label "${Name} (latest-tag)"
+
+        Write-Host "PASS: ${Name}"
+    } catch {
+        $script:failures++
+        Write-Host "FAIL: ${Name} -> $($_.Exception.Message)"
+    } finally {
+        Remove-Item Env:\TAGS_OVERRIDE -ErrorAction SilentlyContinue
+        Remove-Item Env:\CHANGE_TYPE -ErrorAction SilentlyContinue
+        Remove-Item Env:\MODE -ErrorAction SilentlyContinue
+        Remove-Item Env:\SUFFIX -ErrorAction SilentlyContinue
+    }
+}
+
+try {
+    # Corpus from Auto-Tagging-Technical-Plan.md §Test plan (rows 1-7; rows 8-9 are e2e and need the App).
+    Invoke-Case -Name 'Patch bump on 1.3.5'              -Tags @('1.3.5')                -ChangeType 'Patch' -Mode 'release'    -Suffix ''         -ExpectedVersion '1.3.6'            -ExpectedLatestTag '1.3.5'
+    Invoke-Case -Name 'Minor bump on 1.3.5'              -Tags @('1.3.5')                -ChangeType 'Minor' -Mode 'release'    -Suffix ''         -ExpectedVersion '1.4.0'            -ExpectedLatestTag '1.3.5'
+    Invoke-Case -Name 'Major bump on 1.3.5'              -Tags @('1.3.5')                -ChangeType 'Major' -Mode 'release'    -Suffix ''         -ExpectedVersion '2.0.0'            -ExpectedLatestTag '1.3.5'
+    Invoke-Case -Name 'Patch bump, no tags'              -Tags @()                       -ChangeType 'Patch' -Mode 'release'    -Suffix ''         -ExpectedVersion '0.0.1'            -ExpectedLatestTag ''
+    Invoke-Case -Name 'Minor bump ignores pre-release'   -Tags @('1.3.5', '1.4.0-dev.1') -ChangeType 'Minor' -Mode 'release'    -Suffix ''         -ExpectedVersion '1.4.0'            -ExpectedLatestTag '1.3.5'
+    Invoke-Case -Name 'Minor pre-release with suffix'    -Tags @('1.3.5')                -ChangeType 'Minor' -Mode 'prerelease' -Suffix 'dev-x.42' -ExpectedVersion '1.4.0-dev-x.42'   -ExpectedLatestTag '1.3.5'
+    Invoke-Case -Name 'Empty change-type defaults Patch' -Tags @('1.3.5')                -ChangeType ''      -Mode 'release'    -Suffix ''         -ExpectedVersion '1.3.6'            -ExpectedLatestTag '1.3.5'
+
+    # Extra guards beyond the plan corpus.
+    Invoke-Case -Name 'Numeric (not lexical) tag sort'   -Tags @('1.9.0', '1.10.0')      -ChangeType 'Patch' -Mode 'release'    -Suffix ''         -ExpectedVersion '1.10.1'           -ExpectedLatestTag '1.10.0'
+    Invoke-Case -Name 'Leading v prefix tolerated'       -Tags @('v2.1.0')               -ChangeType 'Minor' -Mode 'release'    -Suffix ''         -ExpectedVersion '2.2.0'            -ExpectedLatestTag 'v2.1.0'
+    Invoke-Case -Name 'Release ignores stray suffix'     -Tags @('1.3.5')                -ChangeType 'Patch' -Mode 'release'    -Suffix 'ignored'  -ExpectedVersion '1.3.6'            -ExpectedLatestTag '1.3.5'
+    Invoke-Case -Name 'Only pre-release tags exist'      -Tags @('1.4.0-dev.1')          -ChangeType 'Patch' -Mode 'release'    -Suffix ''         -ExpectedVersion '0.0.1'            -ExpectedLatestTag ''
+
+    if ($failures -gt 0) {
+        throw "$failures test case(s) failed."
+    }
+
+    Write-Host "All compute-next-version test cases passed."
+} finally {
+    Remove-Item -Path $temporaryDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/.github/actions/load-secrets/load-from-keyvault.sh
+++ b/.github/actions/load-secrets/load-from-keyvault.sh
@@ -18,6 +18,17 @@ for secret_name in "${secret_names[@]}"; do
 
   secret_value=$(az keyvault secret show --vault-name "$VAULT_NAME" --name "$secret_name" --query value -o tsv)
 
-  echo "::add-mask::$secret_value"
-  echo "$env_var_name=$secret_value" >> "$GITHUB_ENV"
+  # Mask every line so multi-line secrets (e.g. PEM private keys) never leak in logs.
+  while IFS= read -r secret_line; do
+    [[ -n "$secret_line" ]] && echo "::add-mask::$secret_line"
+  done <<< "$secret_value"
+
+  # Write to $GITHUB_ENV using the heredoc form so multi-line values (e.g. PEM keys)
+  # are preserved. A random delimiter avoids clashing with the secret content.
+  delimiter="ghadelim_${secret_name}_${RANDOM}${RANDOM}"
+  {
+    printf '%s<<%s\n' "$env_var_name" "$delimiter"
+    printf '%s\n' "$secret_value"
+    printf '%s\n' "$delimiter"
+  } >> "$GITHUB_ENV"
 done


### PR DESCRIPTION
This pull request introduces a new reusable GitHub Action, `compute-next-version`, which automates semantic version bumping based on the latest final git tag and a requested change type. The action is fully documented, tested, and integrated into the actions catalog. Additionally, there is an improvement to the `load-from-keyvault.sh` script to better handle and mask multi-line secrets.

**New Action: Semantic Version Computation**

* Added the `compute-next-version` action, which computes the next SemVer version from the latest final (non-pre-release) git tag, supporting major, minor, and patch bumps, with optional pre-release suffixing. [[1]](diffhunk://#diff-eb5ce3b5c01e96a32e0610d4d7b0dc8c3dffb64bdd5cb9bac33f961df23d5d6dR1-R40) [[2]](diffhunk://#diff-fdfcfe3f88f1c73b89fc1d171edd236c764ee4947c391a05930ac2ea3ee25a4cR1-R86)
* Provided comprehensive documentation for the new action, including usage, inputs, outputs, rules, and test instructions in `compute-next-version/README.md`.
* Registered the new action in the main actions catalog in `.github/actions/README.md`.
* Added a PowerShell-based test script, `test.ps1`, to validate version computation logic against a set of test cases.

**Security and Usability Improvements**

* Updated `load-from-keyvault.sh` to safely mask each line of multi-line secrets and correctly write them to `$GITHUB_ENV` using a heredoc with a random delimiter, ensuring secrets like PEM keys are handled securely and without log leakage.