### PR TITLE
Rename parse-rn-task-table to references-parser

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -50,7 +50,7 @@ Usage examples in each action README are sourced from the master workflows in
 | `detect-test-runner` | Detects MTP or VSTest mode from `global.json`. | [detect-test-runner/README.md](detect-test-runner/README.md) |
 | `run-unit-tests` | Runs unit tests for all test projects in a solution. | [run-unit-tests/README.md](run-unit-tests/README.md) |
 | `unit-tests` | Wrapper combining detect + run unit test actions. | [unit-tests/README.md](unit-tests/README.md) |
-| `parse-rn-task-table` | Parses and validates the mandatory PR RN/Task table and renders the sticky-comment summary. | [parse-rn-task-table/README.md](parse-rn-task-table/README.md) |
+| `references-parser` | Parses and validates the mandatory PR `References:` line and renders the sticky-comment summary. | [references-parser/README.md](references-parser/README.md) |
 | `quality-gate-summary` | Aggregates unit-test / SonarCloud / Validator outcomes, renders a Job Summary + sticky PR comment, and fails the job on any failed sub-gate. | [quality-gate-summary/README.md](quality-gate-summary/README.md) |
 
 ## Referencing from a reusable workflow in this repo

--- a/.github/actions/compute-next-version/README.md
+++ b/.github/actions/compute-next-version/README.md
@@ -37,7 +37,7 @@ bumping from the same final version.
   id: version
   uses: SkylineCommunications/_ReusableWorkflows/.github/actions/compute-next-version@main
   with:
-    change-type: ${{ steps.rn-task.outputs.change-type }}
+    change-type: ${{ steps.references.outputs.change-type }}
     mode: prerelease
     suffix: dev-myfeature.42
 ```

--- a/.github/actions/references-parser/README.md
+++ b/.github/actions/references-parser/README.md
@@ -1,8 +1,8 @@
-# parse-rn-task-table
+# references-parser
 
-Parses the `References:` line in a pull request description and validates the mandatory DxM release administration.
+Parses the `References:` line in a pull request description (or squash-merge commit message) and validates the mandatory DxM release administration.
 
-The action finds the `References:` line (e.g. `References: [RN44205] [DCP284603] [RN4345] [DCP28543]`), extracts the bracketed ids, normalizes them to upper-case, validates the id format, resolves the `Change-Type` label, and writes a markdown summary for the `skyline-rn-task` sticky PR comment.
+The action finds the `References:` line (e.g. `References: [RN44205] [DCP284603] [RN4345] [DCP28543]`), extracts the bracketed ids, normalizes them to upper-case, validates the id format, resolves the `Change-Type` label, and writes a markdown summary for the `skyline-references` sticky PR comment.
 
 ## Inputs
 
@@ -36,9 +36,9 @@ The action finds the `References:` line (e.g. `References: [RN44205] [DCP284603]
 ## Usage
 
 ```yaml
-- name: Parse RN/Task references
-  id: rn-task
-  uses: SkylineCommunications/_ReusableWorkflows/.github/actions/parse-rn-task-table@main
+- name: Parse References line
+  id: references
+  uses: SkylineCommunications/_ReusableWorkflows/.github/actions/references-parser@main
   with:
     pr-body: ${{ github.event.pull_request.body }}
     actor: ${{ github.event.pull_request.user.login }}
@@ -49,13 +49,13 @@ The parser does not fail the step for validation errors. It emits `status=failed
 
 ## Sticky comment example
 
-The action renders `comment-file`, which the reusable workflow posts as the `skyline-rn-task` sticky
+The action renders `comment-file`, which the reusable workflow posts as the `skyline-references` sticky
 comment. RN and task ids link to their DataMiner collaboration pages.
 
 A passing PR:
 
 ```markdown
-## PR RN/Task Validation: ✅ **Passed**
+## PR References Validation: ✅ **Passed**
 
 | Item | Value |
 | --- | :---: |
@@ -77,7 +77,7 @@ A Dependabot PR adds a `Dependabot RN-only mode` row, and the **Tasks** section 
 task is linked:
 
 ```markdown
-## PR RN/Task Validation: ✅ **Passed**
+## PR References Validation: ✅ **Passed**
 
 | Item | Value |
 | --- | :---: |
@@ -93,7 +93,7 @@ task is linked:
 A failing PR shows a ❌ status and lists the validation errors:
 
 ```markdown
-## PR RN/Task Validation: ❌ **Failed**
+## PR References Validation: ❌ **Failed**
 
 | Item | Value |
 | --- | :---: |
@@ -114,7 +114,7 @@ Validation errors:
 The PR validation corpus runs through:
 
 ```powershell
-pwsh .github/actions/parse-rn-task-table/test.ps1
+pwsh .github/actions/references-parser/test.ps1
 ```
 
 The same command is wired into [Test composite actions.yml](../../workflows/Test%20composite%20actions.yml).

--- a/.github/actions/references-parser/action.yml
+++ b/.github/actions/references-parser/action.yml
@@ -1,8 +1,8 @@
-name: Parse RN Task Table
+name: References Parser
 description: >
-  Parses the "References:" line from a pull request body, validates the bracketed
-  RN and DCP task ids, resolves the Change-Type label, and renders a markdown
-  summary for a sticky PR comment.
+  Parses the "References:" line from a pull request body (or squash-merge commit message),
+  validates the bracketed RN and DCP task ids, resolves the Change-Type label, and renders a
+  markdown summary for a sticky PR comment.
 
 inputs:
   pr-body:
@@ -35,12 +35,12 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Parse RN/Task table
+    - name: Parse References line
       id: parse
       shell: pwsh
       env:
         PR_BODY: ${{ inputs.pr-body }}
         ACTOR: ${{ inputs.actor }}
         LABELS_JSON: ${{ inputs.labels-json }}
-        COMMENT_HEADER: skyline-rn-task
-      run: '& "$env:GITHUB_ACTION_PATH/parse-rn-task-table.ps1"'
+        COMMENT_HEADER: skyline-references
+      run: '& "$env:GITHUB_ACTION_PATH/references-parser.ps1"'

--- a/.github/actions/references-parser/references-parser.ps1
+++ b/.github/actions/references-parser/references-parser.ps1
@@ -11,7 +11,7 @@ if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
 $prBody = if ($null -ne $env:PR_BODY) { $env:PR_BODY } else { '' }
 $actor = if ($null -ne $env:ACTOR) { $env:ACTOR } else { '' }
 $labelsJson = if ($null -ne $env:LABELS_JSON) { $env:LABELS_JSON } else { '[]' }
-$commentHeader = if ($null -ne $env:COMMENT_HEADER) { $env:COMMENT_HEADER } else { 'skyline-rn-task' }
+$commentHeader = if ($null -ne $env:COMMENT_HEADER) { $env:COMMENT_HEADER } else { 'skyline-references' }
 
 $errors = [System.Collections.Generic.List[string]]::new()
 $allRns = [System.Collections.Generic.List[string]]::new()
@@ -144,7 +144,7 @@ function Write-ValidationComment {
         [AllowEmptyCollection()][string[]]$Tasks
     )
 
-    $commentFile = Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath 'rn-task-validation-comment.md'
+    $commentFile = Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath 'references-validation-comment.md'
     $isDependabot = $script:actor -eq 'dependabot[bot]'
     if ($Status -eq 'failed') {
         $statusIcon = '❌'
@@ -157,7 +157,7 @@ function Write-ValidationComment {
     $content = [System.Collections.Generic.List[string]]::new()
 
     $content.Add("<!-- ${script:commentHeader} -->")
-    $content.Add("## PR RN/Task Validation: ${statusIcon} ${headingText}")
+    $content.Add("## PR References Validation: ${statusIcon} ${headingText}")
     $content.Add('')
     $content.Add('| Item | Value |')
     $content.Add('| --- | :---: |')

--- a/.github/actions/references-parser/test.ps1
+++ b/.github/actions/references-parser/test.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 
 $actionDirectory = Split-Path -Parent $PSCommandPath
-$temporaryDirectory = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "parse-rn-task-table-$([System.Guid]::NewGuid())"
+$temporaryDirectory = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "references-parser-$([System.Guid]::NewGuid())"
 New-Item -Path $temporaryDirectory -ItemType Directory | Out-Null
 
 function Get-OutputValue {
@@ -69,12 +69,12 @@ function Invoke-ParserCase {
     $env:PR_BODY = $Body
     $env:ACTOR = $Actor
     $env:LABELS_JSON = $LabelsJson
-    $env:COMMENT_HEADER = 'skyline-rn-task'
+    $env:COMMENT_HEADER = 'skyline-references'
     $env:GITHUB_OUTPUT = $outputFile
     $env:GITHUB_STEP_SUMMARY = $summaryFile
     $env:GITHUB_WORKSPACE = $workspaceDirectory
 
-    & (Join-Path -Path $actionDirectory -ChildPath 'parse-rn-task-table.ps1')
+    & (Join-Path -Path $actionDirectory -ChildPath 'references-parser.ps1')
 
     $status = Get-OutputValue -Name 'status' -Path $outputFile
     $changeType = Get-OutputValue -Name 'change-type' -Path $outputFile
@@ -135,7 +135,7 @@ try {
 
     # Comment-format cases (lock the sticky-comment structure).
     Invoke-ParserCase -Name '17 comment format happy path' -Body "References: [RN12] [RN13] [DCP35]" -Actor 'human' -LabelsJson '["Change-Type:Minor"]' -ExpectedStatus 'passed' -ExpectedChangeType 'Minor' -ExpectedRnsJson '["RN12","RN13"]' -ExpectedTasksJson '["DCP35"]' -ExpectedCommentContains @(
-        '## PR RN/Task Validation: ✅ **Passed**',
+        '## PR References Validation: ✅ **Passed**',
         '| Status | ✅ |',
         '| Change-Type | Minor |',
         '**Release Notes**',
@@ -145,7 +145,7 @@ try {
         '- [DCP35](https://collaboration.dataminer.services/task/35)'
     ) -ExpectedCommentMissing @('Dependabot RN-only mode', '| RN(s) | Task(s) |', 'Parsed RN ids')
     Invoke-ParserCase -Name '18 comment format failed' -Body "References: [R12] [DCP35]" -Actor 'human' -LabelsJson '[]' -ExpectedStatus 'failed' -ExpectedChangeType '-' -ExpectedRnsJson '-' -ExpectedTasksJson '-' -ExpectedCommentContains @(
-        '## PR RN/Task Validation: ❌ **Failed**',
+        '## PR References Validation: ❌ **Failed**',
         '| Status | ❌ |',
         'Validation errors:'
     )
@@ -160,7 +160,7 @@ try {
         '- [DCP35](https://collaboration.dataminer.services/task/35)'
     )
 
-    Write-Output 'All parse-rn-task-table cases passed.'
+    Write-Output 'All references-parser cases passed.'
 } finally {
     Remove-Item -Path $temporaryDirectory -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -593,19 +593,19 @@ jobs:
           token: ${{ secrets.SONAR_TOKEN }}
           repository: ${{ github.repository }}
 
-  parse-rn-task-table:
-    name: parse-rn-task-table
+  references-parser:
+    name: references-parser
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - name: Run 16-case parser corpus
         shell: pwsh
-        run: ./.github/actions/parse-rn-task-table/test.ps1
+        run: ./.github/actions/references-parser/test.ps1
 
       - name: Invoke composite smoke test
-        id: rn-task
-        uses: ./.github/actions/parse-rn-task-table
+        id: references
+        uses: ./.github/actions/references-parser
         with:
           pr-body: |
             Example change description.
@@ -616,10 +616,10 @@ jobs:
 
       - name: Assert composite outputs
         env:
-          STATUS: ${{ steps.rn-task.outputs.status }}
-          CHANGE_TYPE: ${{ steps.rn-task.outputs.change-type }}
-          RNS: ${{ steps.rn-task.outputs.rns }}
-          TASKS: ${{ steps.rn-task.outputs.tasks }}
+          STATUS: ${{ steps.references.outputs.status }}
+          CHANGE_TYPE: ${{ steps.references.outputs.change-type }}
+          RNS: ${{ steps.references.outputs.rns }}
+          TASKS: ${{ steps.references.outputs.tasks }}
         shell: pwsh
         run: |
           if ($env:STATUS -ne 'passed') { throw "Expected status passed, got '$env:STATUS'." }


### PR DESCRIPTION
This pull request renames and updates the "parse-rn-task-table" GitHub Action to "references-parser" throughout the repository, clarifying its purpose and aligning terminology across documentation, code, and workflows. The action and its related files now consistently refer to parsing and validating the "References:" line in pull requests, and all output, comments, and test cases have been updated to reflect the new naming.

**Action renaming and terminology updates:**

* Renamed the action from `parse-rn-task-table` to `references-parser`, updating all references in filenames, documentation, and workflow usage to the new name. (`.github/actions/parse-rn-task-table/` → `.github/actions/references-parser/`, `.github/actions/README.md`, `.github/workflows/Test composite actions.yml`, [[1]](diffhunk://#diff-02962606ee71e3b3ea3b0c095adc526e9e51e3ba49bc0caf8e6d127d9f78d15eL1-R5) [[2]](diffhunk://#diff-52d6b7f655d938f43fd7629a638b5183e3fcd1c3d302b3d32479aac06fdacb84L53-R53) [[3]](diffhunk://#diff-e5f057197ca7619eafae42928ec9f8beb33ad04e0df9cab134195303fdad9f8cL596-R608)
* Updated all user-facing strings, sticky comment headers, and output files to use "References" terminology instead of "RN/Task", including in markdown summaries and test assertions. [[1]](diffhunk://#diff-02962606ee71e3b3ea3b0c095adc526e9e51e3ba49bc0caf8e6d127d9f78d15eL52-R58) [[2]](diffhunk://#diff-02962606ee71e3b3ea3b0c095adc526e9e51e3ba49bc0caf8e6d127d9f78d15eL80-R80) [[3]](diffhunk://#diff-02962606ee71e3b3ea3b0c095adc526e9e51e3ba49bc0caf8e6d127d9f78d15eL96-R96) [[4]](diffhunk://#diff-49b61a0b0033a0da60d7f422a73a3b8a446c9aa807ea2de30a66de755c717509L160-R160) [[5]](diffhunk://#diff-55ca902f8b74961cf890377cbca30bd23fa15ba172dede4a9f833f899e9190abL138-R138) [[6]](diffhunk://#diff-55ca902f8b74961cf890377cbca30bd23fa15ba172dede4a9f833f899e9190abL148-R148)

**Documentation and usage changes:**

* Revised action and workflow documentation to describe the action as parsing the "References:" line, with updated usage examples and descriptions. (`README.md`, `action.yml`, [[1]](diffhunk://#diff-02962606ee71e3b3ea3b0c095adc526e9e51e3ba49bc0caf8e6d127d9f78d15eL39-R41) [[2]](diffhunk://#diff-6c76b9e94be0653bc4482960586757b3e73a74c9648c4627b75f3b9ffda81c2cL1-R5)
* Updated sample workflow and test script invocations to use the new action name and outputs. [[1]](diffhunk://#diff-bd3f26f878f11582504826b533f52e221adc3d0e53367a134cafd22db3e2cee6L40-R40) [[2]](diffhunk://#diff-e5f057197ca7619eafae42928ec9f8beb33ad04e0df9cab134195303fdad9f8cL619-R622) [[3]](diffhunk://#diff-55ca902f8b74961cf890377cbca30bd23fa15ba172dede4a9f833f899e9190abL4-R4) [[4]](diffhunk://#diff-55ca902f8b74961cf890377cbca30bd23fa15ba172dede4a9f833f899e9190abL72-R77)

**Code and test updates:**

* Refactored environment variable and file naming in the PowerShell implementation and tests to match the new action name and output file conventions. [[1]](diffhunk://#diff-49b61a0b0033a0da60d7f422a73a3b8a446c9aa807ea2de30a66de755c717509L14-R14) [[2]](diffhunk://#diff-49b61a0b0033a0da60d7f422a73a3b8a446c9aa807ea2de30a66de755c717509L147-R147) [[3]](diffhunk://#diff-55ca902f8b74961cf890377cbca30bd23fa15ba172dede4a9f833f899e9190abL163-R163)
* Ensured all test cases and validation comments use the updated terminology and file paths. [[1]](diffhunk://#diff-02962606ee71e3b3ea3b0c095adc526e9e51e3ba49bc0caf8e6d127d9f78d15eL117-R117) [[2]](diffhunk://#diff-55ca902f8b74961cf890377cbca30bd23fa15ba172dede4a9f833f899e9190abL72-R77) [[3]](diffhunk://#diff-55ca902f8b74961cf890377cbca30bd23fa15ba172dede4a9f833f899e9190abL163-R163)