### PR TITLE
Add determine-version GitHub Action

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -45,6 +45,7 @@ Usage examples in each action README are sourced from the master workflows in
 | `update-global-json-sdks` | Rewrites managed `msbuild-sdks` versions in `global.json`. | [update-global-json-sdks/README.md](update-global-json-sdks/README.md) |
 | `apply-catalog-identifiers` | Rewrites manifest `id:` fields from mapping input. | [apply-catalog-identifiers/README.md](apply-catalog-identifiers/README.md) |
 | `compute-next-version` | Computes the next SemVer version from the latest final tag + Change-Type bump. | [compute-next-version/README.md](compute-next-version/README.md) |
+| `determine-version` | Determines the canonical build version (`version` + 4-field `numeric-version`) from the git ref. | [determine-version/README.md](determine-version/README.md) |
 | `apply-source-code-url` | Fills empty `source_code_url:` fields in catalog manifests. | [apply-source-code-url/README.md](apply-source-code-url/README.md) |
 | `sonarcloud-status` | Checks SonarCloud project status and emits analysis flag. | [sonarcloud-status/README.md](sonarcloud-status/README.md) |
 | `detect-test-runner` | Detects MTP or VSTest mode from `global.json`. | [detect-test-runner/README.md](detect-test-runner/README.md) |

--- a/.github/actions/determine-version/README.md
+++ b/.github/actions/determine-version/README.md
@@ -19,15 +19,18 @@ strict 4-field numeric companion for consumers that reject SemVer suffixes.
 | Output | Suffix allowed? | Description |
 | --- | :--: | --- |
 | `version` | ✔ | Full SemVer — for MSBuild `Version` / `PackageVersion`, NuGet, `.dmapp` / Catalog, `.deb` (after its own `~` normalisation), DxM release. |
-| `numeric-version` | ✘ | Strict 4-field `major.minor.patch.<run-number % 65536>` — for `AssemblyVersion` / `FileVersion` and the WiX MSI `ProductVersion`. |
+| `numeric-version` | ✘ | Strict 4-field `major.minor.patch.<run-number>` (every field wrapped `% 65535`) — for `AssemblyVersion` / `FileVersion` and the WiX MSI `ProductVersion`. |
 
 ## Rules
 
 - `numeric-version` = `version` with any pre-release/build suffix (`-…` / `+…`) stripped down to
   `major.minor.patch`, then `run-number` appended as the 4th field. An optional leading `v` on the
   tag is tolerated (and stripped).
-- Each version field is a `UInt16` (max 65535), so the 4th field is always **wrapped** into range
-  (`run_number % 65536`) — a wrap-around, not a clamp, so the value keeps changing across runs.
+- Assembly metadata restricts each version field to **65534** (`UInt16.MaxValue - 1` — every field
+  must be strictly **less than 65535**), so **every field** of `numeric-version` is wrapped into
+  range (`value % 65535`: 65534 → 65534, 65535 → 0, 65536 → 1) — a wrap-around, not a clamp, so the
+  value keeps changing across runs. This also covers the legacy branch version `0.0.<run-number>`,
+  whose patch field is the (unbounded) run number.
 - A tag whose core is not `major.minor.patch` (e.g. `release-1`, `1.2`) fails the action with a
   clear error — such a version could not build anyway.
 - **MSI caveat:** Windows Installer compares only the first **three** fields of `ProductVersion` for

--- a/.github/actions/determine-version/README.md
+++ b/.github/actions/determine-version/README.md
@@ -1,0 +1,55 @@
+# determine-version
+
+Determines the **single canonical build version** shared by every job in the Master Workflow, and a
+strict 4-field numeric companion for consumers that reject SemVer suffixes.
+
+- **Tag builds** use the tag name verbatim (e.g. `2.3.1`, `1.4.0-dev-myfeature.42`).
+- **Branch builds** keep the legacy `0.0.<run-number>` in all modes.
+
+## Inputs
+
+| Input | Required | Description |
+| --- | --- | --- |
+| `ref-type` | yes | The git ref type of the run (`github.ref_type`), `tag` or `branch`. |
+| `ref-name` | yes | The git ref name of the run (`github.ref_name`). Used as the version on tag builds. |
+| `run-number` | yes | The workflow run number (`github.run_number`). Used for the branch version and the 4th numeric field. |
+
+## Outputs
+
+| Output | Suffix allowed? | Description |
+| --- | :--: | --- |
+| `version` | ✔ | Full SemVer — for MSBuild `Version` / `PackageVersion`, NuGet, `.dmapp` / Catalog, `.deb` (after its own `~` normalisation), DxM release. |
+| `numeric-version` | ✘ | Strict 4-field `major.minor.patch.<run-number % 65536>` — for `AssemblyVersion` / `FileVersion` and the WiX MSI `ProductVersion`. |
+
+## Rules
+
+- `numeric-version` = `version` with any pre-release/build suffix (`-…` / `+…`) stripped down to
+  `major.minor.patch`, then `run-number` appended as the 4th field. An optional leading `v` on the
+  tag is tolerated (and stripped).
+- Each version field is a `UInt16` (max 65535), so the 4th field is always **wrapped** into range
+  (`run_number % 65536`) — a wrap-around, not a clamp, so the value keeps changing across runs.
+- A tag whose core is not `major.minor.patch` (e.g. `release-1`, `1.2`) fails the action with a
+  clear error — such a version could not build anyway.
+- **MSI caveat:** Windows Installer compares only the first **three** fields of `ProductVersion` for
+  upgrade detection; the 4th (run number) is parsed but ignored. A real upgrade must still move
+  `major.minor.patch` (the tag / auto-tag bump already does).
+
+## Usage
+
+```yaml
+- name: Determine version
+  id: determine-version
+  uses: SkylineCommunications/_ReusableWorkflows/.github/actions/determine-version@main
+  with:
+    ref-type: ${{ github.ref_type }}
+    ref-name: ${{ github.ref_name }}
+    run-number: ${{ github.run_number }}
+```
+
+## Tests
+
+`test.ps1` runs the version corpus offline (no git repository or network required):
+
+```pwsh
+pwsh -NoProfile -File ./test.ps1
+```

--- a/.github/actions/determine-version/action.yml
+++ b/.github/actions/determine-version/action.yml
@@ -1,0 +1,38 @@
+name: Determine version
+description: >
+  Determines the canonical build version from the git ref: tag builds use
+  the tag name, branch builds use 0.0.<run-number>. Also derives a strict
+  4-field numeric version (pre-release/build suffix stripped, run number
+  appended as 4th field, wrapped into UInt16 range) for MSBuild
+  AssemblyVersion/FileVersion and the WiX MSI ProductVersion.
+
+inputs:
+  ref-type:
+    description: The git ref type of the run (`github.ref_type`), `tag` or `branch`.
+    required: true
+  ref-name:
+    description: The git ref name of the run (`github.ref_name`). Used as the version on tag builds.
+    required: true
+  run-number:
+    description: The workflow run number (`github.run_number`). Used for the branch version and the 4th numeric field.
+    required: true
+
+outputs:
+  version:
+    description: The full SemVer version — the tag name on tag builds (e.g. `2.3.1`, `1.4.0-dev-myfeature.42`), `0.0.<run-number>` on branch builds.
+    value: ${{ steps.determine.outputs.version }}
+  numeric-version:
+    description: Strict 4-field `major.minor.patch.<run-number % 65536>` version with any pre-release/build suffix stripped.
+    value: ${{ steps.determine.outputs.numeric-version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Determine version
+      id: determine
+      shell: pwsh
+      env:
+        REF_TYPE: ${{ inputs.ref-type }}
+        REF_NAME: ${{ inputs.ref-name }}
+        RUN_NUMBER: ${{ inputs.run-number }}
+      run: '& "$env:GITHUB_ACTION_PATH/determine-version.ps1"'

--- a/.github/actions/determine-version/action.yml
+++ b/.github/actions/determine-version/action.yml
@@ -3,8 +3,9 @@ description: >
   Determines the canonical build version from the git ref: tag builds use
   the tag name, branch builds use 0.0.<run-number>. Also derives a strict
   4-field numeric version (pre-release/build suffix stripped, run number
-  appended as 4th field, wrapped into UInt16 range) for MSBuild
-  AssemblyVersion/FileVersion and the WiX MSI ProductVersion.
+  appended as 4th field, every field wrapped into the assembly-metadata
+  range with % 65535) for MSBuild AssemblyVersion/FileVersion and the WiX
+  MSI ProductVersion.
 
 inputs:
   ref-type:
@@ -22,7 +23,7 @@ outputs:
     description: The full SemVer version — the tag name on tag builds (e.g. `2.3.1`, `1.4.0-dev-myfeature.42`), `0.0.<run-number>` on branch builds.
     value: ${{ steps.determine.outputs.version }}
   numeric-version:
-    description: Strict 4-field `major.minor.patch.<run-number % 65536>` version with any pre-release/build suffix stripped.
+    description: Strict 4-field `major.minor.patch.<run-number>` version with any pre-release/build suffix stripped; every field is wrapped into the valid assembly-metadata range (`% 65535`, max 65534).
     value: ${{ steps.determine.outputs.numeric-version }}
 
 runs:

--- a/.github/actions/determine-version/determine-version.ps1
+++ b/.github/actions/determine-version/determine-version.ps1
@@ -1,0 +1,47 @@
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT)) {
+    throw 'GITHUB_OUTPUT must be set.'
+}
+
+$refType = if ($null -eq $env:REF_TYPE) { '' } else { $env:REF_TYPE.Trim().ToLowerInvariant() }
+$refName = if ($null -eq $env:REF_NAME) { '' } else { $env:REF_NAME.Trim() }
+
+if ([string]::IsNullOrWhiteSpace($env:RUN_NUMBER)) {
+    throw 'RUN_NUMBER must be set.'
+}
+$runNumber = [long]$env:RUN_NUMBER.Trim()
+if ($runNumber -lt 0) {
+    throw "RUN_NUMBER must be non-negative, got '$runNumber'."
+}
+
+# Tag builds use the tag name verbatim; branch builds keep the legacy 0.0.<run-number>.
+if ($refType -eq 'tag') {
+    if ([string]::IsNullOrWhiteSpace($refName)) {
+        throw 'REF_NAME must be set for tag builds.'
+    }
+    $version = $refName
+} else {
+    $version = "0.0.$runNumber"
+}
+
+# numeric-version: strip any pre-release/build suffix (-… / +…) down to major.minor.patch,
+# then append the run number as the 4th field. Each version field is a UInt16 (max 65535),
+# so the run number is always wrapped into range (run_number % 65536) — a wrap-around, not
+# a clamp, so the value keeps changing across runs instead of sticking at the ceiling.
+$buildField = $runNumber % 65536
+
+$core = ($version -split '[-+]', 2)[0]
+$match = [regex]::Match($core, '^v?(\d+)\.(\d+)\.(\d+)$')
+if (-not $match.Success) {
+    throw "Cannot derive numeric-version: '$version' does not start with a major.minor.patch core."
+}
+
+$numericVersion = '{0}.{1}.{2}.{3}' -f [int]$match.Groups[1].Value, [int]$match.Groups[2].Value, [int]$match.Groups[3].Value, $buildField
+
+Write-Host "Determined version '$version' and numeric-version '$numericVersion' (ref-type: $refType, run-number: $runNumber)."
+
+@(
+    "version=$version"
+    "numeric-version=$numericVersion"
+) | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8

--- a/.github/actions/determine-version/determine-version.ps1
+++ b/.github/actions/determine-version/determine-version.ps1
@@ -26,18 +26,23 @@ if ($refType -eq 'tag') {
 }
 
 # numeric-version: strip any pre-release/build suffix (-… / +…) down to major.minor.patch,
-# then append the run number as the 4th field. Each version field is a UInt16 (max 65535),
-# so the run number is always wrapped into range (run_number % 65536) — a wrap-around, not
-# a clamp, so the value keeps changing across runs instead of sticking at the ceiling.
-$buildField = $runNumber % 65536
-
+# then append the run number as the 4th field. Assembly metadata restricts each version
+# field to UInt16.MaxValue - 1 (65534) — every field must be strictly less than 65535 — so
+# every field is wrapped into range by subtracting 65535 until it fits (value % 65535).
+# A wrap-around, not a clamp, so the value keeps changing across runs instead of sticking
+# at the ceiling. This also covers the legacy branch version 0.0.<run-number>, whose patch
+# field is the (unbounded) run number.
 $core = ($version -split '[-+]', 2)[0]
 $match = [regex]::Match($core, '^v?(\d+)\.(\d+)\.(\d+)$')
 if (-not $match.Success) {
     throw "Cannot derive numeric-version: '$version' does not start with a major.minor.patch core."
 }
 
-$numericVersion = '{0}.{1}.{2}.{3}' -f [int]$match.Groups[1].Value, [int]$match.Groups[2].Value, [int]$match.Groups[3].Value, $buildField
+$numericVersion = '{0}.{1}.{2}.{3}' -f `
+    ([long]$match.Groups[1].Value % 65535), `
+    ([long]$match.Groups[2].Value % 65535), `
+    ([long]$match.Groups[3].Value % 65535), `
+    ($runNumber % 65535)
 
 Write-Host "Determined version '$version' and numeric-version '$numericVersion' (ref-type: $refType, run-number: $runNumber)."
 

--- a/.github/actions/determine-version/test.ps1
+++ b/.github/actions/determine-version/test.ps1
@@ -1,0 +1,132 @@
+$ErrorActionPreference = 'Stop'
+
+$actionDirectory = Split-Path -Parent $PSCommandPath
+$scriptPath = Join-Path -Path $actionDirectory -ChildPath 'determine-version.ps1'
+$temporaryDirectory = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "determine-version-$([System.Guid]::NewGuid())"
+New-Item -Path $temporaryDirectory -ItemType Directory | Out-Null
+
+function Get-OutputValue {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    $prefix = "${Name}="
+    $line = Get-Content -Path $Path | Where-Object { $_.StartsWith($prefix, [System.StringComparison]::Ordinal) } | Select-Object -Last 1
+    if ($null -eq $line) {
+        return ''
+    }
+
+    return $line.Substring($prefix.Length)
+}
+
+function Assert-Equal {
+    param(
+        [AllowNull()][object]$Actual,
+        [AllowNull()][object]$Expected,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    if ($Actual -ne $Expected) {
+        throw "${Label}: expected '${Expected}', got '${Actual}'."
+    }
+}
+
+$failures = 0
+
+function Invoke-Case {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$RefType,
+        [AllowEmptyString()][string]$RefName,
+        [Parameter(Mandatory)][string]$RunNumber,
+        [Parameter(Mandatory)][string]$ExpectedVersion,
+        [Parameter(Mandatory)][string]$ExpectedNumericVersion
+    )
+
+    $outputFile = Join-Path -Path $script:temporaryDirectory -ChildPath "$([System.Guid]::NewGuid()).txt"
+    New-Item -Path $outputFile -ItemType File | Out-Null
+
+    $env:GITHUB_OUTPUT = $outputFile
+    $env:REF_TYPE = $RefType
+    $env:REF_NAME = $RefName
+    $env:RUN_NUMBER = $RunNumber
+
+    try {
+        & $script:scriptPath | Out-Null
+
+        $version = Get-OutputValue -Name 'version' -Path $outputFile
+        $numericVersion = Get-OutputValue -Name 'numeric-version' -Path $outputFile
+
+        Assert-Equal -Actual $version -Expected $ExpectedVersion -Label "${Name} (version)"
+        Assert-Equal -Actual $numericVersion -Expected $ExpectedNumericVersion -Label "${Name} (numeric-version)"
+
+        Write-Host "PASS: ${Name}"
+    } catch {
+        $script:failures++
+        Write-Host "FAIL: ${Name} -> $($_.Exception.Message)"
+    } finally {
+        Remove-Item Env:\REF_TYPE -ErrorAction SilentlyContinue
+        Remove-Item Env:\REF_NAME -ErrorAction SilentlyContinue
+        Remove-Item Env:\RUN_NUMBER -ErrorAction SilentlyContinue
+    }
+}
+
+function Invoke-FailureCase {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$RefType,
+        [AllowEmptyString()][string]$RefName,
+        [Parameter(Mandatory)][string]$RunNumber
+    )
+
+    $outputFile = Join-Path -Path $script:temporaryDirectory -ChildPath "$([System.Guid]::NewGuid()).txt"
+    New-Item -Path $outputFile -ItemType File | Out-Null
+
+    $env:GITHUB_OUTPUT = $outputFile
+    $env:REF_TYPE = $RefType
+    $env:REF_NAME = $RefName
+    $env:RUN_NUMBER = $RunNumber
+
+    try {
+        & $script:scriptPath | Out-Null
+        $script:failures++
+        Write-Host "FAIL: ${Name} -> expected the script to throw, but it succeeded."
+    } catch {
+        Write-Host "PASS: ${Name} (threw: $($_.Exception.Message))"
+    } finally {
+        Remove-Item Env:\REF_TYPE -ErrorAction SilentlyContinue
+        Remove-Item Env:\REF_NAME -ErrorAction SilentlyContinue
+        Remove-Item Env:\RUN_NUMBER -ErrorAction SilentlyContinue
+    }
+}
+
+try {
+    # Branch builds keep the legacy 0.0.<run-number> in all modes.
+    Invoke-Case -Name 'Branch build'                       -RefType 'branch' -RefName 'dev/my-feature'            -RunNumber '42'    -ExpectedVersion '0.0.42'                 -ExpectedNumericVersion '0.0.42.42'
+    Invoke-Case -Name 'Branch build, large run number'     -RefType 'branch' -RefName 'main'                      -RunNumber '70000' -ExpectedVersion '0.0.70000'              -ExpectedNumericVersion '0.0.70000.4464'
+
+    # Tag builds use the tag name; numeric-version strips the suffix + appends the run number.
+    Invoke-Case -Name 'Final release tag'                  -RefType 'tag'    -RefName '1.2.3'                     -RunNumber '7'     -ExpectedVersion '1.2.3'                  -ExpectedNumericVersion '1.2.3.7'
+    Invoke-Case -Name 'Pre-release tag'                    -RefType 'tag'    -RefName '1.4.0-dev-myfeature.42'    -RunNumber '99'    -ExpectedVersion '1.4.0-dev-myfeature.42' -ExpectedNumericVersion '1.4.0.99'
+    Invoke-Case -Name 'Build-metadata tag'                 -RefType 'tag'    -RefName '2.3.1+build.5'             -RunNumber '3'     -ExpectedVersion '2.3.1+build.5'          -ExpectedNumericVersion '2.3.1.3'
+    Invoke-Case -Name 'Pre-release + metadata tag'         -RefType 'tag'    -RefName '1.2.3-rc.1+meta'           -RunNumber '8'     -ExpectedVersion '1.2.3-rc.1+meta'        -ExpectedNumericVersion '1.2.3.8'
+    Invoke-Case -Name 'Leading v prefix tolerated'         -RefType 'tag'    -RefName 'v1.2.3'                    -RunNumber '5'     -ExpectedVersion 'v1.2.3'                 -ExpectedNumericVersion '1.2.3.5'
+
+    # UInt16 wrap-around on the 4th field (run_number % 65536, never a clamp).
+    Invoke-Case -Name 'Run number wraps at 65536'          -RefType 'tag'    -RefName '1.0.0'                     -RunNumber '65536' -ExpectedVersion '1.0.0'                  -ExpectedNumericVersion '1.0.0.0'
+    Invoke-Case -Name 'Run number above 65536'             -RefType 'tag'    -RefName '1.0.0'                     -RunNumber '70000' -ExpectedVersion '1.0.0'                  -ExpectedNumericVersion '1.0.0.4464'
+
+    # Failure cases: tags that have no major.minor.patch core cannot yield a numeric-version.
+    Invoke-FailureCase -Name 'Non-SemVer tag rejected'     -RefType 'tag'    -RefName 'release-1'                 -RunNumber '1'
+    Invoke-FailureCase -Name 'Two-part tag rejected'       -RefType 'tag'    -RefName '1.2'                       -RunNumber '1'
+    Invoke-FailureCase -Name 'Empty tag name rejected'     -RefType 'tag'    -RefName ''                          -RunNumber '1'
+
+    if ($failures -gt 0) {
+        throw "$failures test case(s) failed."
+    }
+
+    Write-Host "All determine-version test cases passed."
+} finally {
+    Remove-Item -Path $temporaryDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/.github/actions/determine-version/test.ps1
+++ b/.github/actions/determine-version/test.ps1
@@ -104,7 +104,7 @@ function Invoke-FailureCase {
 try {
     # Branch builds keep the legacy 0.0.<run-number> in all modes.
     Invoke-Case -Name 'Branch build'                       -RefType 'branch' -RefName 'dev/my-feature'            -RunNumber '42'    -ExpectedVersion '0.0.42'                 -ExpectedNumericVersion '0.0.42.42'
-    Invoke-Case -Name 'Branch build, large run number'     -RefType 'branch' -RefName 'main'                      -RunNumber '70000' -ExpectedVersion '0.0.70000'              -ExpectedNumericVersion '0.0.70000.4464'
+    Invoke-Case -Name 'Branch build, large run number'     -RefType 'branch' -RefName 'main'                      -RunNumber '70000' -ExpectedVersion '0.0.70000'              -ExpectedNumericVersion '0.0.4465.4465'
 
     # Tag builds use the tag name; numeric-version strips the suffix + appends the run number.
     Invoke-Case -Name 'Final release tag'                  -RefType 'tag'    -RefName '1.2.3'                     -RunNumber '7'     -ExpectedVersion '1.2.3'                  -ExpectedNumericVersion '1.2.3.7'
@@ -113,9 +113,11 @@ try {
     Invoke-Case -Name 'Pre-release + metadata tag'         -RefType 'tag'    -RefName '1.2.3-rc.1+meta'           -RunNumber '8'     -ExpectedVersion '1.2.3-rc.1+meta'        -ExpectedNumericVersion '1.2.3.8'
     Invoke-Case -Name 'Leading v prefix tolerated'         -RefType 'tag'    -RefName 'v1.2.3'                    -RunNumber '5'     -ExpectedVersion 'v1.2.3'                 -ExpectedNumericVersion '1.2.3.5'
 
-    # UInt16 wrap-around on the 4th field (run_number % 65536, never a clamp).
-    Invoke-Case -Name 'Run number wraps at 65536'          -RefType 'tag'    -RefName '1.0.0'                     -RunNumber '65536' -ExpectedVersion '1.0.0'                  -ExpectedNumericVersion '1.0.0.0'
-    Invoke-Case -Name 'Run number above 65536'             -RefType 'tag'    -RefName '1.0.0'                     -RunNumber '70000' -ExpectedVersion '1.0.0'                  -ExpectedNumericVersion '1.0.0.4464'
+    # Fields must be < 65535 (assembly-metadata max 65534): wrap-around % 65535, never a clamp.
+    Invoke-Case -Name 'Run number 65534 fits'              -RefType 'tag'    -RefName '1.0.0'                     -RunNumber '65534' -ExpectedVersion '1.0.0'                  -ExpectedNumericVersion '1.0.0.65534'
+    Invoke-Case -Name 'Run number wraps at 65535'          -RefType 'tag'    -RefName '1.0.0'                     -RunNumber '65535' -ExpectedVersion '1.0.0'                  -ExpectedNumericVersion '1.0.0.0'
+    Invoke-Case -Name 'Run number 65536 wraps to 1'        -RefType 'tag'    -RefName '1.0.0'                     -RunNumber '65536' -ExpectedVersion '1.0.0'                  -ExpectedNumericVersion '1.0.0.1'
+    Invoke-Case -Name 'Run number above 65536'             -RefType 'tag'    -RefName '1.0.0'                     -RunNumber '70000' -ExpectedVersion '1.0.0'                  -ExpectedNumericVersion '1.0.0.4465'
 
     # Failure cases: tags that have no major.minor.patch core cannot yield a numeric-version.
     Invoke-FailureCase -Name 'Non-SemVer tag rejected'     -RefType 'tag'    -RefName 'release-1'                 -RunNumber '1'

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -55,6 +55,12 @@ on:
         required: false
         type: string
 
+      # Comma-separated list of project names to `dotnet publish` for Linux and package as `.deb`.
+      # Empty ⇒ the Ubuntu packaging and `.deb` release flows are skipped.
+      dxm-projects-ubuntu:
+        required: false
+        type: string
+
     secrets:
       SONAR_TOKEN:
         required: false
@@ -119,6 +125,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       has-dataminer-projects: ${{ steps.detect-projects.outputs.has-dataminer-projects }}
+      has-wix-projects: ${{ steps.detect-projects.outputs.has-wix-projects }}
+      has-ubuntu-dxm: ${{ inputs.dxm-projects-ubuntu != '' }}
       solution-path: ${{ steps.find-solution-file.outputs.path }}
     steps:
       - uses: actions/checkout@v7
@@ -156,6 +164,7 @@ jobs:
           $solutionPath = "$env:SOLUTION_PATH"
           $solutionDir  = Split-Path $solutionPath -Parent
           $hasDataminerProjects = $false
+          $hasWixProjects = $false
 
           # Use dotnet sln list to enumerate projects in the solution (skip 2-line header)
           $projectPaths = dotnet sln "$solutionPath" list | Select-Object -Skip 2 | Where-Object { $_ -ne '' }
@@ -164,17 +173,33 @@ jobs:
             $absolutePath = Join-Path $solutionDir ($relativePath -replace '\\', '/')
             if (-not (Test-Path $absolutePath)) { continue }
 
+            # Check for WiX installer projects (by extension)
+            if ($relativePath -like '*.wixproj') {
+              Write-Output "Found WiX project: $relativePath"
+              $hasWixProjects = $true
+              if ($hasDataminerProjects) { break }
+              continue
+            }
+
             [xml]$content = Get-Content $absolutePath
 
             # Check for Skyline.DataMiner.Sdk projects (based on DataMinerType property)
-            if ($content.SelectNodes("//DataMinerType").Count -gt 0) {
+            if (-not $hasDataminerProjects -and $content.SelectNodes("//DataMinerType").Count -gt 0) {
               Write-Output "Found DataMiner project: $relativePath"
               $hasDataminerProjects = $true
-              break
             }
+
+            # Check for WiX custom-action projects (based on WixToolset.Dtf package references)
+            if (-not $hasWixProjects -and $content.SelectNodes("//PackageReference[@Include='WixToolset.Dtf.CustomAction' or @Include='WixToolset.Dtf.WindowsInstaller']").Count -gt 0) {
+              Write-Output "Found WiX-related project: $relativePath"
+              $hasWixProjects = $true
+            }
+
+            if ($hasDataminerProjects -and $hasWixProjects) { break }
           }
 
           echo "has-dataminer-projects=$($hasDataminerProjects.ToString().ToLower())" >> $env:GITHUB_OUTPUT
+          echo "has-wix-projects=$($hasWixProjects.ToString().ToLower())" >> $env:GITHUB_OUTPUT
         shell: pwsh
 
   ci:

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -629,6 +629,44 @@ jobs:
           if ($rns -ne '["RN12"]') { throw "Unexpected RN output: $rns" }
           if ($tasks -ne '["DCP35"]') { throw "Unexpected tasks output: $tasks" }
 
+  determine-version:
+    name: determine-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run 12-case version corpus
+        shell: pwsh
+        run: ./.github/actions/determine-version/test.ps1
+
+      - name: Tag build smoke test
+        id: tag-build
+        uses: ./.github/actions/determine-version
+        with:
+          ref-type: tag
+          ref-name: 1.4.0-dev-myfeature.42
+          run-number: 99
+
+      - name: Branch build smoke test
+        id: branch-build
+        uses: ./.github/actions/determine-version
+        with:
+          ref-type: branch
+          ref-name: main
+          run-number: 70000
+
+      - name: Assert composite outputs
+        env:
+          TAG_VERSION: ${{ steps.tag-build.outputs.version }}
+          TAG_NUMERIC: ${{ steps.tag-build.outputs.numeric-version }}
+          BRANCH_VERSION: ${{ steps.branch-build.outputs.version }}
+          BRANCH_NUMERIC: ${{ steps.branch-build.outputs.numeric-version }}
+        run: |
+          test "$TAG_VERSION" = "1.4.0-dev-myfeature.42"
+          test "$TAG_NUMERIC" = "1.4.0.99"
+          test "$BRANCH_VERSION" = "0.0.70000"
+          test "$BRANCH_NUMERIC" = "0.0.70000.4464"
+
   quality-gate-summary:
     name: quality-gate-summary
     runs-on: ubuntu-latest

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -635,7 +635,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Run 12-case version corpus
+      - name: Run 14-case version corpus
         shell: pwsh
         run: ./.github/actions/determine-version/test.ps1
 
@@ -665,7 +665,7 @@ jobs:
           test "$TAG_VERSION" = "1.4.0-dev-myfeature.42"
           test "$TAG_NUMERIC" = "1.4.0.99"
           test "$BRANCH_VERSION" = "0.0.70000"
-          test "$BRANCH_NUMERIC" = "0.0.70000.4464"
+          test "$BRANCH_NUMERIC" = "0.0.4465.4465"
 
   quality-gate-summary:
     name: quality-gate-summary


### PR DESCRIPTION
This pull request introduces a new reusable composite GitHub Action called `determine-version`, which standardizes how build versions are computed across workflows. The action determines both a canonical SemVer version and a strict 4-field numeric version for use in MSBuild and installer scenarios. The PR also enhances project detection logic in the master workflow and adds test coverage for the new action.

**Key changes:**

### New reusable action for build versioning

* Added the `determine-version` composite action under `.github/actions/determine-version`, including implementation (`determine-version.ps1`), documentation (`README.md`), action metadata (`action.yml`), and comprehensive offline tests (`test.ps1`). This action outputs both a full SemVer version and a 4-field numeric version, handling tags, branches, and edge cases robustly. [[1]](diffhunk://#diff-a0686b87706f437d2ea9f411252ddd381399eaf02c391f911cbf2158e58adcc1R1-R47) [[2]](diffhunk://#diff-64f5056f156060043dc451631e5fcb4990061c3dfe978e9ea7f9e1a766e6d255R1-R38) [[3]](diffhunk://#diff-2b126896dadb9cbc5ac377210663bbecbf9c4ec787516b78e97ffed2b22ed909R1-R55) [[4]](diffhunk://#diff-6e71dacaaf8140a719f076c757ec40ba5d494e79d6f93c3f999e87cc228ae309R1-R132)

* Documented the new action in the main actions README, describing its purpose and linking to its documentation.

### Workflow and project detection enhancements

* Updated the master workflow to expose new inputs and outputs: added `dxm-projects-ubuntu` input and outputs for `has-wix-projects` and `has-ubuntu-dxm`, supporting conditional logic for packaging and installer flows. [[1]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R58-R63) [[2]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R128-R129)

* Improved project detection logic to identify WiX installer projects and custom-action projects, in addition to DataMiner projects, within the solution. This ensures more accurate workflow branching and output reporting. [[1]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R167) [[2]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R176-R202)

### Test coverage

* Added a new job to the composite actions test workflow to run the full test corpus for `determine-version` and verify its outputs in both tag and branch scenarios.