### PR TITLE
Add remove-wix-projects GitHub Action and support for Wix projects

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -46,6 +46,7 @@ Usage examples in each action README are sourced from the master workflows in
 | `apply-catalog-identifiers` | Rewrites manifest `id:` fields from mapping input. | [apply-catalog-identifiers/README.md](apply-catalog-identifiers/README.md) |
 | `compute-next-version` | Computes the next SemVer version from the latest final tag + Change-Type bump. | [compute-next-version/README.md](compute-next-version/README.md) |
 | `determine-version` | Determines the canonical build version (`version` + 4-field `numeric-version`) from the git ref. | [determine-version/README.md](determine-version/README.md) |
+| `remove-wix-projects` | Strips WiX projects from a solution for cross-platform CI builds. | [remove-wix-projects/README.md](remove-wix-projects/README.md) |
 | `apply-source-code-url` | Fills empty `source_code_url:` fields in catalog manifests. | [apply-source-code-url/README.md](apply-source-code-url/README.md) |
 | `sonarcloud-status` | Checks SonarCloud project status and emits analysis flag. | [sonarcloud-status/README.md](sonarcloud-status/README.md) |
 | `detect-test-runner` | Detects MTP or VSTest mode from `global.json`. | [detect-test-runner/README.md](detect-test-runner/README.md) |

--- a/.github/actions/determine-version/README.md
+++ b/.github/actions/determine-version/README.md
@@ -19,20 +19,22 @@ strict 4-field numeric companion for consumers that reject SemVer suffixes.
 | Output | Suffix allowed? | Description |
 | --- | :--: | --- |
 | `version` | ✔ | Full SemVer — for MSBuild `Version` / `PackageVersion`, NuGet, `.dmapp` / Catalog, `.deb` (after its own `~` normalisation), DxM release. |
-| `numeric-version` | ✘ | Strict 4-field `major.minor.patch.<run-number>` (every field wrapped `% 65535`) — for `AssemblyVersion` / `FileVersion` and the WiX MSI `ProductVersion`. |
+| `numeric-version` | ✘ | Strict 4-field `major.minor.patch.<build>` (every field wrapped `% 65535`) — for `AssemblyVersion` / `FileVersion` and the WiX MSI `ProductVersion`. `<build>` = the run number, or the version's own 4th field when it already has one. |
 
 ## Rules
 
-- `numeric-version` = `version` with any pre-release/build suffix (`-…` / `+…`) stripped down to
-  `major.minor.patch`, then `run-number` appended as the 4th field. An optional leading `v` on the
-  tag is tolerated (and stripped).
+- `numeric-version` = `version` with any pre-release/build suffix (`-…` / `+…`) stripped down to the
+  numeric core, then made 4-field. A 3-field core (`major.minor.patch` — SemVer tags) gets
+  `run-number` appended as the 4th field; a **4-field core** (e.g. date-based tags like
+  `2026.07.08.230`) **keeps its own 4th field** and the run number is not used. An optional leading
+  `v` on the tag is tolerated (and stripped).
 - Assembly metadata restricts each version field to **65534** (`UInt16.MaxValue - 1` — every field
   must be strictly **less than 65535**), so **every field** of `numeric-version` is wrapped into
   range (`value % 65535`: 65534 → 65534, 65535 → 0, 65536 → 1) — a wrap-around, not a clamp, so the
   value keeps changing across runs. This also covers the legacy branch version `0.0.<run-number>`,
   whose patch field is the (unbounded) run number.
-- A tag whose core is not `major.minor.patch` (e.g. `release-1`, `1.2`) fails the action with a
-  clear error — such a version could not build anyway.
+- A tag whose core is not `major.minor.patch` or `major.minor.patch.build` (e.g. `release-1`, `1.2`)
+  fails the action with a clear error — such a version could not build anyway.
 - **MSI caveat:** Windows Installer compares only the first **three** fields of `ProductVersion` for
   upgrade detection; the 4th (run number) is parsed but ignored. A real upgrade must still move
   `major.minor.patch` (the tag / auto-tag bump already does).

--- a/.github/actions/determine-version/action.yml
+++ b/.github/actions/determine-version/action.yml
@@ -2,10 +2,11 @@ name: Determine version
 description: >
   Determines the canonical build version from the git ref: tag builds use
   the tag name, branch builds use 0.0.<run-number>. Also derives a strict
-  4-field numeric version (pre-release/build suffix stripped, run number
-  appended as 4th field, every field wrapped into the assembly-metadata
-  range with % 65535) for MSBuild AssemblyVersion/FileVersion and the WiX
-  MSI ProductVersion.
+  4-field numeric version (pre-release/build suffix stripped; the run
+  number is appended as 4th field unless the version already has one, e.g.
+  date-based tags; every field wrapped into the assembly-metadata range
+  with % 65535) for MSBuild AssemblyVersion/FileVersion and the WiX MSI
+  ProductVersion.
 
 inputs:
   ref-type:
@@ -23,7 +24,7 @@ outputs:
     description: The full SemVer version — the tag name on tag builds (e.g. `2.3.1`, `1.4.0-dev-myfeature.42`), `0.0.<run-number>` on branch builds.
     value: ${{ steps.determine.outputs.version }}
   numeric-version:
-    description: Strict 4-field `major.minor.patch.<run-number>` version with any pre-release/build suffix stripped; every field is wrapped into the valid assembly-metadata range (`% 65535`, max 65534).
+    description: Strict 4-field `major.minor.patch.<build>` version with any pre-release/build suffix stripped; `<build>` is the run number, or the version's own 4th field when it already has one; every field is wrapped into the valid assembly-metadata range (`% 65535`, max 65534).
     value: ${{ steps.determine.outputs.numeric-version }}
 
 runs:

--- a/.github/actions/determine-version/determine-version.ps1
+++ b/.github/actions/determine-version/determine-version.ps1
@@ -25,24 +25,29 @@ if ($refType -eq 'tag') {
     $version = "0.0.$runNumber"
 }
 
-# numeric-version: strip any pre-release/build suffix (-… / +…) down to major.minor.patch,
-# then append the run number as the 4th field. Assembly metadata restricts each version
-# field to UInt16.MaxValue - 1 (65534) — every field must be strictly less than 65535 — so
-# every field is wrapped into range by subtracting 65535 until it fits (value % 65535).
-# A wrap-around, not a clamp, so the value keeps changing across runs instead of sticking
-# at the ceiling. This also covers the legacy branch version 0.0.<run-number>, whose patch
-# field is the (unbounded) run number.
+# numeric-version: strip any pre-release/build suffix (-… / +…) down to the numeric core,
+# then ensure 4 fields. A 3-field core (major.minor.patch — SemVer tags) gets the run
+# number appended as the 4th field; a 4-field core (e.g. date-based tags like
+# 2026.07.08.230) already carries its own 4th field, which is kept (run number unused).
+# Assembly metadata restricts each version field to UInt16.MaxValue - 1 (65534) — every
+# field must be strictly less than 65535 — so every field is wrapped into range by
+# subtracting 65535 until it fits (value % 65535). A wrap-around, not a clamp, so the
+# value keeps changing across runs instead of sticking at the ceiling. This also covers
+# the legacy branch version 0.0.<run-number>, whose patch field is the (unbounded) run
+# number.
 $core = ($version -split '[-+]', 2)[0]
-$match = [regex]::Match($core, '^v?(\d+)\.(\d+)\.(\d+)$')
+$match = [regex]::Match($core, '^v?(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?$')
 if (-not $match.Success) {
-    throw "Cannot derive numeric-version: '$version' does not start with a major.minor.patch core."
+    throw "Cannot derive numeric-version: '$version' does not start with a major.minor.patch[.build] core."
 }
+
+$fourthField = if ($match.Groups[4].Success) { [long]$match.Groups[4].Value } else { $runNumber }
 
 $numericVersion = '{0}.{1}.{2}.{3}' -f `
     ([long]$match.Groups[1].Value % 65535), `
     ([long]$match.Groups[2].Value % 65535), `
     ([long]$match.Groups[3].Value % 65535), `
-    ($runNumber % 65535)
+    ($fourthField % 65535)
 
 Write-Host "Determined version '$version' and numeric-version '$numericVersion' (ref-type: $refType, run-number: $runNumber)."
 

--- a/.github/actions/determine-version/test.ps1
+++ b/.github/actions/determine-version/test.ps1
@@ -113,15 +113,21 @@ try {
     Invoke-Case -Name 'Pre-release + metadata tag'         -RefType 'tag'    -RefName '1.2.3-rc.1+meta'           -RunNumber '8'     -ExpectedVersion '1.2.3-rc.1+meta'        -ExpectedNumericVersion '1.2.3.8'
     Invoke-Case -Name 'Leading v prefix tolerated'         -RefType 'tag'    -RefName 'v1.2.3'                    -RunNumber '5'     -ExpectedVersion 'v1.2.3'                 -ExpectedNumericVersion '1.2.3.5'
 
+    # 4-part cores (e.g. date-based tags) keep their own 4th field — the run number is not appended.
+    Invoke-Case -Name 'Four-part date tag'                 -RefType 'tag'    -RefName '2026.07.08.230'            -RunNumber '44'    -ExpectedVersion '2026.07.08.230'         -ExpectedNumericVersion '2026.7.8.230'
+    Invoke-Case -Name 'Four-part tag keeps 4th field'      -RefType 'tag'    -RefName '1.2.3.4'                   -RunNumber '99'    -ExpectedVersion '1.2.3.4'                -ExpectedNumericVersion '1.2.3.4'
+    Invoke-Case -Name 'Four-part tag wraps 4th field'      -RefType 'tag'    -RefName '1.2.3.70000'               -RunNumber '7'     -ExpectedVersion '1.2.3.70000'            -ExpectedNumericVersion '1.2.3.4465'
+
     # Fields must be < 65535 (assembly-metadata max 65534): wrap-around % 65535, never a clamp.
     Invoke-Case -Name 'Run number 65534 fits'              -RefType 'tag'    -RefName '1.0.0'                     -RunNumber '65534' -ExpectedVersion '1.0.0'                  -ExpectedNumericVersion '1.0.0.65534'
     Invoke-Case -Name 'Run number wraps at 65535'          -RefType 'tag'    -RefName '1.0.0'                     -RunNumber '65535' -ExpectedVersion '1.0.0'                  -ExpectedNumericVersion '1.0.0.0'
     Invoke-Case -Name 'Run number 65536 wraps to 1'        -RefType 'tag'    -RefName '1.0.0'                     -RunNumber '65536' -ExpectedVersion '1.0.0'                  -ExpectedNumericVersion '1.0.0.1'
     Invoke-Case -Name 'Run number above 65536'             -RefType 'tag'    -RefName '1.0.0'                     -RunNumber '70000' -ExpectedVersion '1.0.0'                  -ExpectedNumericVersion '1.0.0.4465'
 
-    # Failure cases: tags that have no major.minor.patch core cannot yield a numeric-version.
+    # Failure cases: tags that have no major.minor.patch[.build] core cannot yield a numeric-version.
     Invoke-FailureCase -Name 'Non-SemVer tag rejected'     -RefType 'tag'    -RefName 'release-1'                 -RunNumber '1'
     Invoke-FailureCase -Name 'Two-part tag rejected'       -RefType 'tag'    -RefName '1.2'                       -RunNumber '1'
+    Invoke-FailureCase -Name 'Five-part tag rejected'      -RefType 'tag'    -RefName '1.2.3.4.5'                 -RunNumber '1'
     Invoke-FailureCase -Name 'Empty tag name rejected'     -RefType 'tag'    -RefName ''                          -RunNumber '1'
 
     if ($failures -gt 0) {

--- a/.github/actions/quality-gate-summary/README.md
+++ b/.github/actions/quality-gate-summary/README.md
@@ -28,6 +28,7 @@ action still produces the Job Summary and enforces the gate.
 | `unit-tests-outcome` | yes | — | `steps.<id>.outcome` of the unit-tests step (`success` / `failure` / `skipped`). |
 | `sonar-outcome` | no | `''` | `steps.<id>.outcome` of the SonarCloud Quality Gate step. Empty ⇒ row omitted. |
 | `sonar-status` | no | `''` | `steps.<id>.outputs.quality-gate-status` (`OK` / `FAILED` / ...). |
+| `sonarcloud-project-name` | no | `''` | SonarCloud project key. Non-empty ⇒ a link to the project's new-code dashboard for the current branch/tag is appended to the summary. |
 | `validator-outcome` | no | `''` | `steps.<id>.outcome` of the Validator Quality Gate step. Empty ⇒ row omitted. |
 | `validator-state-file` | no | `''` | Absolute path to `validator-gate-state.json` produced by the Validator Quality Gate step. When provided, a detailed table (current vs previous critical/major/minor) is rendered. |
 | `major-change-checker-outcome` | no | `''` | `steps.<id>.outcome` of the Major Change Checker Quality Gate step. Empty ⇒ row omitted. |

--- a/.github/actions/quality-gate-summary/action.yml
+++ b/.github/actions/quality-gate-summary/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "Quality-gate-status output from sonarqube-quality-gate-action (OK|FAILED|...)."
     required: false
     default: ''
+  sonarcloud-project-name:
+    description: "SonarCloud project key. When non-empty, a link to the project's new-code dashboard for the current branch/tag is appended to the summary."
+    required: false
+    default: ''
   validator-outcome:
     description: "Outcome of the Validator Quality Gate step. Leave empty to omit the Validator sub-gate."
     required: false
@@ -61,6 +65,8 @@ runs:
         UNIT_TESTS_OUTCOME: ${{ inputs.unit-tests-outcome }}
         SONAR_OUTCOME: ${{ inputs.sonar-outcome }}
         SONAR_STATUS: ${{ inputs.sonar-status }}
+        SONAR_PROJECT_NAME: ${{ inputs.sonarcloud-project-name }}
+        BRANCH_NAME: ${{ github.ref_name }}
         VALIDATOR_OUTCOME: ${{ inputs.validator-outcome }}
         VALIDATOR_STATE_FILE: ${{ inputs.validator-state-file }}
         MCC_OUTCOME: ${{ inputs.major-change-checker-outcome }}

--- a/.github/actions/quality-gate-summary/render.sh
+++ b/.github/actions/quality-gate-summary/render.sh
@@ -278,6 +278,11 @@ comment_file="${GITHUB_WORKSPACE}/quality-gate-comment.md"
     fi
   fi
 
+  if [ -n "${SONAR_PROJECT_NAME:-}" ]; then
+    echo "_SonarCloud: [new-code dashboard for \`${BRANCH_NAME:-}\`](https://sonarcloud.io/summary/new_code?id=${SONAR_PROJECT_NAME}&branch=${BRANCH_NAME:-})_"
+    echo ""
+  fi
+
   if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] || [ "${GITHUB_EVENT_NAME:-}" = "pull_request_target" ]; then
     echo "_See the [Actions run]($RUN_URL) for full logs._"
   fi

--- a/.github/actions/remove-wix-projects/README.md
+++ b/.github/actions/remove-wix-projects/README.md
@@ -1,0 +1,46 @@
+# remove-wix-projects
+
+Strips WiX-related projects from a solution so the **cross-platform `ci` job** can build it — WiX
+cannot be built on Linux (per the WiX maintainers). The real installer build happens in the Windows
+packaging job, which builds the **unmodified** solution.
+
+Removed from the solution:
+
+- every `*.wixproj`;
+- every `*.csproj` that references `WixToolset.Dtf.CustomAction` or
+  `WixToolset.Dtf.WindowsInstaller` (WiX custom actions — they only exist to be embedded in the MSI).
+
+The projects are only removed from the **solution file** in the runner's workspace; nothing is
+deleted from disk or committed.
+
+## Inputs
+
+| Input | Required | Description |
+| --- | --- | --- |
+| `solution-path` | yes | Path to the solution file (`.sln` / `.slnx`) to strip. |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `removed-count` | The number of WiX-related projects removed. `0` when nothing matched (idempotent). |
+
+## Usage
+
+```yaml
+- name: Remove WiX projects (not buildable in cross-platform CI)
+  if: needs.discover_projects.outputs.has-wix-projects == 'true'
+  uses: SkylineCommunications/_ReusableWorkflows/.github/actions/remove-wix-projects@main
+  with:
+    solution-path: ${{ needs.discover_projects.outputs.solution-path }}
+```
+
+## Tests
+
+`test.ps1` scaffolds a temporary solution (plain libs + a `.wixproj` + a `WixToolset.Dtf`
+custom-action `.csproj`) with the `dotnet` CLI, runs the script, and asserts only the WiX-related
+projects were removed (plus an idempotent re-run):
+
+```pwsh
+pwsh -NoProfile -File ./test.ps1
+```

--- a/.github/actions/remove-wix-projects/action.yml
+++ b/.github/actions/remove-wix-projects/action.yml
@@ -1,0 +1,27 @@
+name: Remove WiX projects
+description: >
+  Removes WiX installer projects (*.wixproj) and WiX custom-action projects
+  (*.csproj referencing WixToolset.Dtf.CustomAction /
+  WixToolset.Dtf.WindowsInstaller) from a solution. WiX cannot be built on
+  Linux, so the cross-platform ci job strips these projects before building;
+  the real installer build happens in the Windows packaging job.
+
+inputs:
+  solution-path:
+    description: Path to the solution file (`.sln` / `.slnx`) to strip.
+    required: true
+
+outputs:
+  removed-count:
+    description: The number of WiX-related projects removed from the solution.
+    value: ${{ steps.remove.outputs.removed-count }}
+
+runs:
+  using: composite
+  steps:
+    - name: Remove WiX projects
+      id: remove
+      shell: bash
+      env:
+        SOLUTION_PATH: ${{ inputs.solution-path }}
+      run: bash "${{ github.action_path }}/remove-wix-projects.sh"

--- a/.github/actions/remove-wix-projects/remove-wix-projects.sh
+++ b/.github/actions/remove-wix-projects/remove-wix-projects.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Removes WiX-related projects from the solution so the cross-platform ci job can
+# build it (WiX cannot be built on Ubuntu, per the WiX maintainers; installers are
+# built in the Windows packaging job instead):
+#   * every *.wixproj
+#   * every *.csproj that references WixToolset.Dtf.CustomAction or
+#     WixToolset.Dtf.WindowsInstaller (WiX custom actions)
+#
+# Env (set by action.yml):
+#   SOLUTION_PATH : path to the .sln/.slnx file.
+#
+# Outputs (written to $GITHUB_OUTPUT):
+#   removed-count : number of projects removed.
+set -euo pipefail
+
+if [[ -z "${SOLUTION_PATH:-}" ]]; then
+  echo "SOLUTION_PATH must be set." >&2
+  exit 1
+fi
+
+solution_dir=$(dirname "$SOLUTION_PATH")
+removed=0
+
+# `dotnet sln list` prints a 2-line header before the project paths.
+while IFS= read -r relative_path; do
+  relative_path=${relative_path%$'\r'}  # tolerate CRLF output (Windows)
+  [[ -z "$relative_path" ]] && continue
+  relative_unix=${relative_path//\\//}
+  absolute_path="$solution_dir/$relative_unix"
+
+  remove=false
+  if [[ "$relative_unix" == *.wixproj ]]; then
+    remove=true
+  elif [[ "$relative_unix" == *.csproj && -f "$absolute_path" ]] \
+      && grep -qE 'WixToolset\.Dtf\.(CustomAction|WindowsInstaller)' "$absolute_path"; then
+    remove=true
+  fi
+
+  if [[ "$remove" == "true" ]]; then
+    echo "Removing WiX-related project from the solution: $relative_path"
+    dotnet sln "$SOLUTION_PATH" remove "$absolute_path"
+    removed=$((removed + 1))
+  fi
+done < <(dotnet sln "$SOLUTION_PATH" list | tail -n +3)
+
+echo "Removed $removed WiX-related project(s)."
+echo "removed-count=$removed" >> "$GITHUB_OUTPUT"

--- a/.github/actions/remove-wix-projects/test.ps1
+++ b/.github/actions/remove-wix-projects/test.ps1
@@ -1,0 +1,116 @@
+$ErrorActionPreference = 'Stop'
+
+$actionDirectory = Split-Path -Parent $PSCommandPath
+$scriptPath = Join-Path -Path $actionDirectory -ChildPath 'remove-wix-projects.sh'
+$temporaryDirectory = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "remove-wix-projects-$([System.Guid]::NewGuid())"
+New-Item -Path $temporaryDirectory -ItemType Directory | Out-Null
+
+# Resolve bash: on Linux/macOS runners it is on PATH; on Windows fall back to Git for Windows.
+$bash = (Get-Command bash -ErrorAction SilentlyContinue).Source
+if ([string]::IsNullOrWhiteSpace($bash)) {
+    $bash = Join-Path $env:ProgramFiles 'Git\bin\bash.exe'
+}
+if (-not (Test-Path $bash)) {
+    throw 'bash was not found (required to run remove-wix-projects.sh).'
+}
+
+function Get-OutputValue {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    $prefix = "${Name}="
+    $line = Get-Content -Path $Path | Where-Object { $_.StartsWith($prefix, [System.StringComparison]::Ordinal) } | Select-Object -Last 1
+    if ($null -eq $line) {
+        return ''
+    }
+
+    return $line.Substring($prefix.Length)
+}
+
+function Assert-Equal {
+    param(
+        [AllowNull()][object]$Actual,
+        [AllowNull()][object]$Expected,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    if ($Actual -ne $Expected) {
+        throw "${Label}: expected '${Expected}', got '${Actual}'."
+    }
+}
+
+try {
+    # --- Scaffold a solution with 4 projects: 1 plain lib, 1 test-ish lib, 1 wixproj, 1 Dtf custom-action csproj.
+    Push-Location $temporaryDirectory
+    try {
+        dotnet new sln --name Demo | Out-Null
+        $solutionPath = Get-ChildItem -Path $temporaryDirectory -File | Where-Object { $_.Extension -in '.sln', '.slnx' } | Select-Object -First 1 -ExpandProperty FullName
+        if ([string]::IsNullOrWhiteSpace($solutionPath)) { throw 'Solution file was not created.' }
+
+        dotnet new classlib -n PlainLib -o PlainLib | Out-Null
+        dotnet new classlib -n OtherLib -o OtherLib | Out-Null
+        dotnet sln $solutionPath add PlainLib/PlainLib.csproj OtherLib/OtherLib.csproj | Out-Null
+
+        New-Item -ItemType Directory -Path Installer | Out-Null
+        Set-Content -Path Installer/Installer.wixproj -Value '<Project Sdk="WixToolset.Sdk/6.0.0"></Project>'
+        dotnet sln $solutionPath add Installer/Installer.wixproj | Out-Null
+
+        New-Item -ItemType Directory -Path CustomActions | Out-Null
+        Set-Content -Path CustomActions/CustomActions.csproj -Value @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Dtf.CustomAction" Version="6.0.0" />
+  </ItemGroup>
+</Project>
+'@
+        dotnet sln $solutionPath add CustomActions/CustomActions.csproj | Out-Null
+    } finally {
+        Pop-Location
+    }
+
+    # --- Run the script.
+    $outputFile = Join-Path -Path $temporaryDirectory -ChildPath 'github-output.txt'
+    New-Item -Path $outputFile -ItemType File | Out-Null
+    $env:GITHUB_OUTPUT = $outputFile
+    $env:SOLUTION_PATH = $solutionPath
+
+    try {
+        & $bash $scriptPath
+        if ($LASTEXITCODE -ne 0) { throw "remove-wix-projects.sh exited with $LASTEXITCODE." }
+    } finally {
+        Remove-Item Env:\SOLUTION_PATH -ErrorAction SilentlyContinue
+    }
+
+    # --- Assert: wixproj + Dtf csproj removed, plain libs kept, count = 2.
+    $remaining = @(dotnet sln $solutionPath list | Select-Object -Skip 2 | Where-Object { $_ -ne '' } | ForEach-Object { $_ -replace '\\', '/' })
+
+    Assert-Equal -Actual (Get-OutputValue -Name 'removed-count' -Path $outputFile) -Expected '2' -Label 'removed-count'
+    Assert-Equal -Actual ($remaining -contains 'Installer/Installer.wixproj') -Expected $false -Label 'wixproj removed'
+    Assert-Equal -Actual ($remaining -contains 'CustomActions/CustomActions.csproj') -Expected $false -Label 'Dtf csproj removed'
+    Assert-Equal -Actual ($remaining -contains 'PlainLib/PlainLib.csproj') -Expected $true -Label 'plain lib kept'
+    Assert-Equal -Actual ($remaining -contains 'OtherLib/OtherLib.csproj') -Expected $true -Label 'other lib kept'
+
+    # --- Idempotency: running again removes nothing and succeeds.
+    $outputFile2 = Join-Path -Path $temporaryDirectory -ChildPath 'github-output-2.txt'
+    New-Item -Path $outputFile2 -ItemType File | Out-Null
+    $env:GITHUB_OUTPUT = $outputFile2
+    $env:SOLUTION_PATH = $solutionPath
+
+    try {
+        & $bash $scriptPath
+        if ($LASTEXITCODE -ne 0) { throw "remove-wix-projects.sh (2nd run) exited with $LASTEXITCODE." }
+    } finally {
+        Remove-Item Env:\SOLUTION_PATH -ErrorAction SilentlyContinue
+    }
+
+    Assert-Equal -Actual (Get-OutputValue -Name 'removed-count' -Path $outputFile2) -Expected '0' -Label 'removed-count (idempotent re-run)'
+
+    Write-Host 'All remove-wix-projects test cases passed.'
+} finally {
+    Remove-Item -Path $temporaryDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -202,9 +202,25 @@ jobs:
           echo "has-wix-projects=$($hasWixProjects.ToString().ToLower())" >> $env:GITHUB_OUTPUT
         shell: pwsh
 
+  determine_version:
+    name: Determine Version
+    needs: [validate_trigger]
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.determine-version.outputs.version }}
+      numeric-version: ${{ steps.determine-version.outputs.numeric-version }}
+    steps:
+      - name: Determine version
+        id: determine-version
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/determine-version@main
+        with:
+          ref-type: ${{ github.ref_type }}
+          ref-name: ${{ github.ref_name }}
+          run-number: ${{ github.run_number }}
+
   ci:
     name: CI
-    needs: [check_oidc, discover_projects]
+    needs: [check_oidc, discover_projects, determine_version]
     runs-on: ${{ inputs.runs-on }}
     permissions:
       contents: read
@@ -247,7 +263,7 @@ jobs:
           dataminer-token: ${{ env.DATAMINER_TOKEN }}
           repository: ${{ github.repository }}
           has-dataminer-projects: ${{ needs.discover_projects.outputs.has-dataminer-projects }}
-          check-sonar: ${{ github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != '' }}
+          check-sonar: ${{ github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != '' && needs.check_oidc.outputs.is-fork != 'true' }}
           check-dataminer: ${{ github.ref_type == 'tag' && needs.discover_projects.outputs.has-dataminer-projects == 'true' }}
 
       - name: Enable long paths
@@ -276,8 +292,9 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           HAS_DM_PROJECTS: ${{ needs.discover_projects.outputs.has-dataminer-projects }}
           SONAR_PROJECT_NAME: ${{ inputs.sonarcloud-project-name }}
+          IS_FORK: ${{ needs.check_oidc.outputs.is-fork }}
         run: |
-          if [[ "$GH_ACTOR" != "dependabot[bot]" ]] && [[ -n "$SONAR_PROJECT_NAME" ]]; then
+          if [[ "$GH_ACTOR" != "dependabot[bot]" ]] && [[ -n "$SONAR_PROJECT_NAME" ]] && [[ "$IS_FORK" != "true" ]]; then
             dotnet tool install dotnet-sonarscanner --global
           fi
 
@@ -295,7 +312,19 @@ jobs:
       # ──────────────────────────────────────────────────────────────
       # A. DataMiner-specific setup
       # ──────────────────────────────────────────────────────────────
+      - name: Require dxm-id-file.json for DxM repositories
+        if: needs.discover_projects.outputs.has-wix-projects == 'true' || needs.discover_projects.outputs.has-ubuntu-dxm == 'true'
+        run: |
+          if [ ! -f "dxm-id-file.json" ]; then
+            echo "::error::dxm-id-file.json is required for DxM repositories but was not found at the repository root."
+            exit 1
+          fi
 
+      - name: Remove WiX projects (not buildable in cross-platform CI)
+        if: needs.discover_projects.outputs.has-wix-projects == 'true'
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/remove-wix-projects@main
+        with:
+          solution-path: ${{ needs.discover_projects.outputs.solution-path }}
       - name: Update msbuild-sdks in global.json
         if: needs.discover_projects.outputs.has-dataminer-projects == 'true'
         uses: SkylineCommunications/_ReusableWorkflows/.github/actions/update-global-json-sdks@main
@@ -332,14 +361,14 @@ jobs:
       # ──────────────────────────────────────────────────────────────
 
       - name: Prepare SonarCloud Variables
-        if: github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != ''
+        if: github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != '' && needs.check_oidc.outputs.is-fork != 'true'
         id: prepSonarCloudVar
         env:
           OWNER: ${{ github.repository_owner }}
         run: echo "lowerCaseOwner=${OWNER,,}" >> "$GITHUB_ENV"
 
       - name: Get SonarCloud Status
-        if: github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != ''
+        if: github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != '' && needs.check_oidc.outputs.is-fork != 'true'
         id: get-sonarcloud-status
         uses: SkylineCommunications/_ReusableWorkflows/.github/actions/sonarcloud-status@main
         with:
@@ -349,7 +378,7 @@ jobs:
           repository: ${{ github.repository }}
 
       - name: Trigger Initial Analysis
-        if: github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != '' && steps.get-sonarcloud-status.outputs.needs-initial-analysis == 'true'
+        if: github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != '' && needs.check_oidc.outputs.is-fork != 'true' && steps.get-sonarcloud-status.outputs.needs-initial-analysis == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_PROJECT_NAME: ${{ inputs.sonarcloud-project-name }}
@@ -374,7 +403,7 @@ jobs:
         continue-on-error: true
 
       - name: Start Analysis
-        if: github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != ''
+        if: github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != '' && needs.check_oidc.outputs.is-fork != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_PROJECT_NAME: ${{ inputs.sonarcloud-project-name }}
@@ -397,28 +426,23 @@ jobs:
       # C. Build
       # ──────────────────────────────────────────────────────────────
 
-      - name: Determine version
-        id: determine-version
-        env:
-          REF_TYPE: ${{ github.ref_type }}
-          REF_NAME: ${{ github.ref_name }}
-          RUN_NUMBER: ${{ github.run_number }}
-        run: |
-          if [[ "$REF_TYPE" == "tag" ]]; then
-            echo "version=$REF_NAME" >> $GITHUB_OUTPUT
-          else
-            echo "version=0.0.$RUN_NUMBER" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-
       - name: Build
         env:
           OVERRIDE_CATALOG_DOWNLOAD_TOKEN: ${{ secrets.OVERRIDE_CATALOG_DOWNLOAD_TOKEN }}
           SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
-          VERSION: ${{ steps.determine-version.outputs.version }}
+          VERSION: ${{ needs.determine_version.outputs.version }}
           CONFIGURATION: ${{ inputs.configuration }}
           DEBUG_FLAG: ${{ inputs.debug }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
+          # Transitional (until the Windows packaging job exists): tag builds still produce
+          # the NuGet/DataMiner packages here for the downstream sign/upload jobs; branch
+          # and PR builds are validation-only, so packaging is off (also keeps the catalog
+          # download token out of fork CI, which has no secrets).
+          packaging_flags=()
+          if [[ "$REF_TYPE" != "tag" ]]; then
+            packaging_flags+=( -p:GeneratePackageOnBuild=false -p:GenerateDataMinerPackage=false )
+          fi
           dotnet build "$SOLUTION_PATH" \
             -p:Version="$VERSION" \
             -p:PackageVersion="$VERSION" \
@@ -427,7 +451,8 @@ jobs:
             -p:CatalogPublishKeyName="DATAMINER_TOKEN" \
             -p:CatalogDefaultDownloadKeyName="OVERRIDE_CATALOG_DOWNLOAD_TOKEN" \
             -p:SkylineDataMinerSdkDebug="$DEBUG_FLAG" \
-            -p:PackageOutputPath="${GITHUB_WORKSPACE}/_NuGetOutput"
+            -p:PackageOutputPath="${GITHUB_WORKSPACE}/_NuGetOutput" \
+            "${packaging_flags[@]}"
 
       # ──────────────────────────────────────────────────────────────
       # D. Test & Quality Gate
@@ -440,7 +465,7 @@ jobs:
           configuration: ${{ inputs.configuration }}
 
       - name: Stop Analysis
-        if: github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != ''
+        if: github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != '' && needs.check_oidc.outputs.is-fork != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MSYS_NO_PATHCONV: '1'
@@ -449,7 +474,7 @@ jobs:
         continue-on-error: true
 
       - name: SonarCloud Quality Gate check
-        if: github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != ''
+        if: github.actor != 'dependabot[bot]' && inputs.sonarcloud-project-name != '' && needs.check_oidc.outputs.is-fork != 'true'
         id: sonarcloud-quality-gate-check
         uses: sonarsource/sonarqube-quality-gate-action@8e9b0ca0a7273d6f16986388d98393efdfcf56fd
         with:
@@ -463,8 +488,9 @@ jobs:
         uses: SkylineCommunications/_ReusableWorkflows/.github/actions/quality-gate-summary@main
         with:
           unit-tests-outcome: ${{ steps.unit-tests.outcome }}
-          sonar-outcome: ${{ inputs.sonarcloud-project-name != '' && steps.sonarcloud-quality-gate-check.outcome || '' }}
-          sonar-status: ${{ inputs.sonarcloud-project-name != '' && steps.sonarcloud-quality-gate-check.outputs.quality-gate-status || '' }}
+          sonar-outcome: ${{ inputs.sonarcloud-project-name != '' && needs.check_oidc.outputs.is-fork != 'true' && steps.sonarcloud-quality-gate-check.outcome || '' }}
+          sonar-status: ${{ inputs.sonarcloud-project-name != '' && needs.check_oidc.outputs.is-fork != 'true' && steps.sonarcloud-quality-gate-check.outputs.quality-gate-status || '' }}
+          sonarcloud-project-name: ${{ github.actor != 'dependabot[bot]' && needs.check_oidc.outputs.is-fork != 'true' && inputs.sonarcloud-project-name || '' }}
           dependabot-bypass: ${{ github.actor == 'dependabot[bot]' }}
 
       # ──────────────────────────────────────────────────────────────
@@ -512,7 +538,7 @@ jobs:
         env:
           SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
           PACKAGE_NAME: ${{ steps.packageName.outputs.name }}
-          PACKAGE_VERSION: ${{ github.ref_name }}
+          PACKAGE_VERSION: ${{ needs.determine_version.outputs.version }}
           DEBUG_FLAG: ${{ inputs.debug }}
         run: |
           find . -type f \( -name "*.dmapp" -o -name "*.dmtest" \) -print0 | while IFS= read -r -d '' file; do

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -212,7 +212,7 @@ jobs:
     steps:
       - name: Determine version
         id: determine-version
-        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/determine-version@CI
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/determine-version@main
         with:
           ref-type: ${{ github.ref_type }}
           ref-name: ${{ github.ref_name }}
@@ -322,7 +322,7 @@ jobs:
 
       - name: Remove WiX projects (not buildable in cross-platform CI)
         if: needs.discover_projects.outputs.has-wix-projects == 'true'
-        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/remove-wix-projects@CI
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/remove-wix-projects@main
         with:
           solution-path: ${{ needs.discover_projects.outputs.solution-path }}
       - name: Update msbuild-sdks in global.json

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -212,7 +212,7 @@ jobs:
     steps:
       - name: Determine version
         id: determine-version
-        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/determine-version@main
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/determine-version@CI
         with:
           ref-type: ${{ github.ref_type }}
           ref-name: ${{ github.ref_name }}

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -322,7 +322,7 @@ jobs:
 
       - name: Remove WiX projects (not buildable in cross-platform CI)
         if: needs.discover_projects.outputs.has-wix-projects == 'true'
-        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/remove-wix-projects@main
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/remove-wix-projects@CI
         with:
           solution-path: ${{ needs.discover_projects.outputs.solution-path }}
       - name: Update msbuild-sdks in global.json

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -667,6 +667,50 @@ jobs:
           test "$BRANCH_VERSION" = "0.0.70000"
           test "$BRANCH_NUMERIC" = "0.0.4465.4465"
 
+  remove-wix-projects:
+    name: remove-wix-projects
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run offline test corpus
+        shell: pwsh
+        run: ./.github/actions/remove-wix-projects/test.ps1
+
+      - name: Scaffold a solution with WiX projects
+        id: scaffold
+        run: |
+          demo_dir="${RUNNER_TEMP}/wix-demo"
+          mkdir -p "$demo_dir"
+          cd "$demo_dir"
+          dotnet new sln --name Demo
+          solution_path=$(find "$demo_dir" -maxdepth 1 -name 'Demo.sln*' | head -n 1)
+          dotnet new classlib -n PlainLib -o PlainLib
+          dotnet sln "$solution_path" add PlainLib/PlainLib.csproj
+          mkdir Installer
+          echo '<Project Sdk="WixToolset.Sdk/6.0.0"></Project>' > Installer/Installer.wixproj
+          dotnet sln "$solution_path" add Installer/Installer.wixproj
+          echo "solution-path=$solution_path" >> "$GITHUB_OUTPUT"
+
+      - name: Invoke composite smoke test
+        id: remove
+        uses: ./.github/actions/remove-wix-projects
+        with:
+          solution-path: ${{ steps.scaffold.outputs.solution-path }}
+
+      - name: Assert removal
+        env:
+          REMOVED_COUNT: ${{ steps.remove.outputs.removed-count }}
+          SOLUTION_PATH: ${{ steps.scaffold.outputs.solution-path }}
+        run: |
+          test "$REMOVED_COUNT" = "1"
+          remaining=$(dotnet sln "$SOLUTION_PATH" list | tail -n +3)
+          echo "$remaining" | grep -q 'PlainLib'
+          if echo "$remaining" | grep -q 'wixproj'; then
+            echo 'wixproj was not removed'
+            exit 1
+          fi
+
   quality-gate-summary:
     name: quality-gate-summary
     runs-on: ubuntu-latest
@@ -687,6 +731,19 @@ jobs:
         env:
           STATUS: ${{ steps.all-pass.outputs.status }}
         run: test "$STATUS" = "passed"
+
+      - name: Sonar link rendered when project name given
+        id: sonar-link
+        uses: ./.github/actions/quality-gate-summary
+        with:
+          post-pr-comment: 'false'
+          unit-tests-outcome: success
+          sonar-outcome: success
+          sonar-status: PASSED
+          sonarcloud-project-name: my-org_my-project
+
+      - name: Assert sonar link in comment file
+        run: grep -q 'https://sonarcloud.io/summary/new_code?id=my-org_my-project' "$GITHUB_WORKSPACE/quality-gate-comment.md"
 
       - name: Unit test failure fails the gate
         id: ut-fail

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -635,7 +635,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Run 14-case version corpus
+      - name: Run 18-case version corpus
         shell: pwsh
         run: ./.github/actions/determine-version/test.ps1
 


### PR DESCRIPTION
This pull request introduces a new GitHub Action, `remove-wix-projects`, which strips WiX-related projects from solution files to enable cross-platform CI builds (since WiX projects cannot be built on Linux). It also improves SonarCloud integration and refines workflow logic to better support forks and versioning. The most important changes are grouped below.

**New Action: Remove WiX Projects**

* Added the `remove-wix-projects` composite action, including documentation, implementation script (`remove-wix-projects.sh`), and a PowerShell test suite (`test.ps1`). This action removes all `*.wixproj` files and any `*.csproj` referencing WiX custom action packages from the solution file, without deleting files on disk. [[1]](diffhunk://#diff-42ae29bd266233262ae5b555f822a64d51954083bb112f0f90cd5c7f03f418b6R1-R46) [[2]](diffhunk://#diff-13bef2668109fe9de640b395b694e3c7f1165bcc1bd0d79a60fd174c08b100e9R1-R27) [[3]](diffhunk://#diff-82f22d1b846748351894b84d386694496d4b0ced42c288b0bb7bcad5242b862aR1-R47) [[4]](diffhunk://#diff-57d4a5af3c5a8dc0989064ce4662a43de8f8cf97d20d80d85c148f27382eae97R1-R116)
* Registered the new action in the root actions README, making it discoverable for other workflows.
* Integrated the action into the main workflow to automatically strip WiX projects for cross-platform CI runs, only when WiX projects are detected.

**Workflow Improvements and SonarCloud Integration**

* Enhanced SonarCloud-related steps to avoid running SonarCloud analysis on forked repositories, preventing issues with missing secrets and permissions. This includes updating conditionals for SonarCloud steps and environment variables. [[1]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3L250-R266) [[2]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R295-R297) [[3]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3L335-R371) [[4]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3L352-R381) [[5]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3L377-R406)
* Added a new input, `sonarcloud-project-name`, to the `quality-gate-summary` action, allowing a direct link to the SonarCloud new-code dashboard in job summaries. Updated documentation and the rendering script accordingly. [[1]](diffhunk://#diff-ab3b63f6113204606206535698575200218d4ae8636b27483e632906d0dfef15R20-R23) [[2]](diffhunk://#diff-ab3b63f6113204606206535698575200218d4ae8636b27483e632906d0dfef15R68-R69) [[3]](diffhunk://#diff-3f409e564aa0eebc3068955afe3b652f2e147763e8bfc0e68564eb724cf1799fR31) [[4]](diffhunk://#diff-51f6a2f79d6a0f9e30da5160786defd27617f35d65f21ae6939b3f1de56eeefcR281-R285)

**Versioning and Build Logic**

* Refactored the version determination logic into a dedicated `determine_version` job, and updated the build job to consume its outputs. This centralizes versioning and improves maintainability. [[1]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R205-R223) [[2]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3L400-R445)

**Quality and Safety Enhancements**

* Added a step to require `dxm-id-file.json` for DxM repositories when WiX or Ubuntu DxM projects are present, enforcing repository standards.

These changes collectively improve CI reliability, cross-platform compatibility, and reporting clarity.