### PR TITLE
Restructure Master Workflow: dedicated packaging & signing jobs (package_windows / package_ubuntu)

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -47,6 +47,7 @@ Usage examples in each action README are sourced from the master workflows in
 | `compute-next-version` | Computes the next SemVer version from the latest final tag + Change-Type bump. | [compute-next-version/README.md](compute-next-version/README.md) |
 | `determine-version` | Determines the canonical build version (`version` + 4-field `numeric-version`) from the git ref. | [determine-version/README.md](determine-version/README.md) |
 | `remove-wix-projects` | Strips WiX projects from a solution for cross-platform CI builds. | [remove-wix-projects/README.md](remove-wix-projects/README.md) |
+| `package-debian` | Builds a `.deb` per DxM project from per-project Debian skeletons. | [package-debian/README.md](package-debian/README.md) |
 | `apply-source-code-url` | Fills empty `source_code_url:` fields in catalog manifests. | [apply-source-code-url/README.md](apply-source-code-url/README.md) |
 | `sonarcloud-status` | Checks SonarCloud project status and emits analysis flag. | [sonarcloud-status/README.md](sonarcloud-status/README.md) |
 | `detect-test-runner` | Detects MTP or VSTest mode from `global.json`. | [detect-test-runner/README.md](detect-test-runner/README.md) |

--- a/.github/actions/package-debian/README.md
+++ b/.github/actions/package-debian/README.md
@@ -1,0 +1,52 @@
+# package-debian
+
+Builds a Debian package (`.deb`) for each listed DxM project — the port of the Azure
+`default-cd-linux.yml` packaging steps, restructured so **one repo can ship several `.deb`s**:
+
+- each project ships its **own** packaging skeleton at
+  `<project>/packaging/Debian/content/` (`DEBIAN/{control,conffiles,preinst,postinst,prerm,postrm}`
+  + `lib/systemd/system/<service>.service`);
+- each project is staged in its **own temp tree**, so multiple `.deb`s never share or clobber a
+  single `packaging/Debian/content`;
+- the **project folder name** is the Debian service name and install path
+  (`opt/skyline-communications/<name>`).
+
+Per project: validate skeleton → stage → `dotnet publish -r linux-x64 --self-contained` →
+optional SBOM (`usr/share/doc/skyline-communications-<name>`, full releases) → copy `conffiles`
+from the publish output → substitute `<VERSION>` in `DEBIAN/control` → fix permissions →
+`dpkg-deb --build` → `<output>/<name>_<version>.deb`.
+
+## Inputs
+
+| Input | Required | Description |
+| --- | --- | --- |
+| `projects` | yes | Comma-separated DxM project paths (relative to the repo root). |
+| `version` | yes | Canonical build version (from `determine-version`). Debian-normalised here: `x.y.z-suffix` → `x.y.z~suffix` (dashes in the suffix removed, dots preserved). |
+| `generate-sbom` | no | `'true'` ⇒ generate an SBOM per project (requires the `dataminer-sbom` tool on the PATH; full releases only). Default `'false'`. |
+| `configuration` | no | `dotnet publish` configuration. Default `Release`. |
+| `output-directory` | no | Directory receiving the `.deb` files. Default `output`. |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `package-count` | Number of `.deb` packages built. Fails the action when 0. |
+
+## Usage
+
+```yaml
+- name: Build Debian packages
+  uses: SkylineCommunications/_ReusableWorkflows/.github/actions/package-debian@main
+  with:
+    projects: ${{ inputs.dxm-projects-ubuntu }}
+    version: ${{ needs.determine_version.outputs.version }}
+    generate-sbom: ${{ !contains(github.ref_name, '-') }}
+```
+
+## Tests
+
+Covered by the `package-debian` job in
+[`../../workflows/Test composite actions.yml`](../../workflows/Test%20composite%20actions.yml),
+which scaffolds two console projects with Debian skeletons and asserts the built `.deb`s
+(name, `~`-normalised version, publish output and conffile contents). `dpkg-deb` requires a
+Linux runner, so there is no local `test.ps1`.

--- a/.github/actions/package-debian/action.yml
+++ b/.github/actions/package-debian/action.yml
@@ -1,0 +1,46 @@
+name: Package Debian services
+description: >
+  Builds a Debian package (`.deb`) for each listed DxM project. Each project
+  is staged in its own temporary tree from the project's packaging/Debian
+  skeleton, published self-contained for linux-x64, versioned, and built
+  with dpkg-deb. Optionally generates an SBOM into
+  usr/share/doc/skyline-communications-<project> (full releases).
+
+inputs:
+  projects:
+    description: Comma-separated list of DxM project paths (relative to the repo root). The project folder name is the Debian service name.
+    required: true
+  version:
+    description: The canonical build version (from `determine-version`). Normalised for Debian (`x.y.z-suffix` → `x.y.z~suffix`).
+    required: true
+  generate-sbom:
+    description: When `true`, generate an SBOM into `usr/share/doc/skyline-communications-<project>` (requires the `dataminer-sbom` tool; full releases only).
+    required: false
+    default: 'false'
+  configuration:
+    description: The build configuration passed to `dotnet publish`.
+    required: false
+    default: 'Release'
+  output-directory:
+    description: Directory receiving the built `.deb` files.
+    required: false
+    default: 'output'
+
+outputs:
+  package-count:
+    description: The number of `.deb` packages built.
+    value: ${{ steps.package.outputs.package-count }}
+
+runs:
+  using: composite
+  steps:
+    - name: Package Debian services
+      id: package
+      shell: bash
+      env:
+        PROJECTS: ${{ inputs.projects }}
+        VERSION: ${{ inputs.version }}
+        GENERATE_SBOM: ${{ inputs.generate-sbom }}
+        CONFIGURATION: ${{ inputs.configuration }}
+        OUTPUT_DIR: ${{ inputs.output-directory }}
+      run: bash "${{ github.action_path }}/package-debian.sh"

--- a/.github/actions/package-debian/package-debian.sh
+++ b/.github/actions/package-debian/package-debian.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Builds one .deb per listed DxM project (ported from the Azure default-cd-linux.yml,
+# restructured for multiple projects per repository):
+#   * each project ships its own packaging skeleton at <project>/packaging/Debian/content/
+#     (DEBIAN/{control,conffiles,preinst,postinst,prerm,postrm} + systemd unit);
+#   * each project is staged in its OWN temp tree so multiple .debs never share or
+#     clobber a single packaging/Debian/content;
+#   * the project folder name is the Debian service name.
+#
+# Env (set by action.yml):
+#   PROJECTS      : comma-separated project paths relative to the repo root.
+#   VERSION       : canonical build version (Debian-normalised here: x.y.z-suffix -> x.y.z~suffix).
+#   GENERATE_SBOM : 'true' => generate SBOM into usr/share/doc/skyline-communications-<name>.
+#   CONFIGURATION : dotnet publish configuration.
+#   OUTPUT_DIR    : directory receiving the built .deb files.
+#
+# Outputs (written to $GITHUB_OUTPUT):
+#   package-count : number of .deb packages built.
+set -euo pipefail
+
+if [[ -z "${PROJECTS:-}" ]]; then
+  echo "PROJECTS must be set." >&2
+  exit 1
+fi
+if [[ -z "${VERSION:-}" ]]; then
+  echo "VERSION must be set." >&2
+  exit 1
+fi
+configuration="${CONFIGURATION:-Release}"
+output_dir="${OUTPUT_DIR:-output}"
+
+# --- Debian version normalisation -------------------------------------------------
+# Pre-release x.y.z-suffix -> x.y.z~suffix (dashes inside the suffix removed; '~' sorts
+# before the final release in dpkg ordering). Any character outside [A-Za-z0-9.~+] is
+# stripped. Unlike the legacy Azure sed, dots are preserved.
+raw_version="$VERSION"
+if [[ "$raw_version" == *-* ]]; then
+  prefix="${raw_version%%-*}"
+  suffix="${raw_version#*-}"
+  deb_version="${prefix}~${suffix//-/}"
+else
+  deb_version="$raw_version"
+fi
+deb_version=$(printf '%s' "$deb_version" | tr -cd 'A-Za-z0-9.~+')
+if [[ -z "$deb_version" ]]; then
+  echo "::error::Version '$raw_version' becomes empty after Debian sanitisation." >&2
+  exit 1
+fi
+echo "Debian package version: $deb_version"
+
+mkdir -p "$output_dir"
+package_count=0
+
+IFS=',' read -r -a projects <<< "$PROJECTS"
+for project in "${projects[@]}"; do
+  # Trim surrounding whitespace.
+  project=$(printf '%s' "$project" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+  [[ -z "$project" ]] && continue
+
+  service_name=$(basename "$project")
+  skeleton="$project/packaging/Debian"
+
+  # 0. Validate: every listed project must ship the Debian skeleton.
+  if [[ ! -f "$skeleton/content/DEBIAN/control" ]]; then
+    echo "::error::Project '$project' is listed in dxm-projects-ubuntu but has no $skeleton/content/DEBIAN/control." >&2
+    exit 1
+  fi
+
+  echo "── Packaging '$service_name' ──"
+  staging=$(mktemp -d)
+
+  # 1. Stage: copy the project's packaging skeleton into its own temp tree.
+  cp -r "$skeleton" "$staging/Debian"
+  content="$staging/Debian/content"
+
+  # 2. Publish self-contained for linux-x64 into opt/skyline-communications/<name>.
+  publish_dir="$content/opt/skyline-communications/$service_name"
+  dotnet publish "$project" -c "$configuration" -r linux-x64 --self-contained true -o "$publish_dir"
+
+  # 3. SBOM (full releases only): usr/share/doc/skyline-communications-<name>,
+  #    matching the Azure reusable pipelines.
+  if [[ "${GENERATE_SBOM:-false}" == "true" ]]; then
+    sbom_dir="$content/usr/share/doc/skyline-communications-$service_name"
+    mkdir -p "$sbom_dir"
+    dataminer-sbom generate \
+      --solution-path "$PWD" \
+      --package-version "$raw_version" \
+      --package-supplier "Skyline Communications" \
+      --output "$sbom_dir"
+  fi
+
+  # 4. conffiles: copy each listed configuration file from the publish output to its
+  #    target directory (ported from the Azure pipeline).
+  conf_file="$content/DEBIAN/conffiles"
+  if [[ -f "$conf_file" ]]; then
+    while IFS= read -r line; do
+      line=${line%$'\r'}
+      [[ -z "$line" ]] && continue
+
+      rel_path="${line#/}"
+      file_name=$(basename "$rel_path")
+      target_dir="$content/$(dirname "$rel_path")"
+      publish_file="$publish_dir/$file_name"
+
+      mkdir -p "$target_dir"
+      if [[ -f "$publish_file" ]]; then
+        echo "Copying conffile $file_name -> $target_dir"
+        cp "$publish_file" "$target_dir"
+      else
+        echo "::warning::Expected conffile '$file_name' not found in the publish output of '$service_name'."
+      fi
+    done < "$conf_file"
+  else
+    echo "No conffiles file for '$service_name' - skipping."
+  fi
+
+  # 5. Version: substitute <VERSION> in DEBIAN/control.
+  sed -i "s/<VERSION>/$deb_version/g" "$content/DEBIAN/control"
+
+  # 6. Permissions: 755 for DEBIAN dir + maintainer scripts, 644 for control.
+  chmod 755 "$content/DEBIAN"
+  chmod 644 "$content/DEBIAN/control"
+  for script in preinst postinst prerm postrm; do
+    [[ -f "$content/DEBIAN/$script" ]] && chmod 755 "$content/DEBIAN/$script"
+  done
+
+  # 7. Build the package (dpkg-deb instead of FPM, see the Azure pipeline note).
+  dpkg-deb --build "$content" "$output_dir/${service_name}_${deb_version}.deb"
+  package_count=$((package_count + 1))
+
+  rm -rf "$staging"
+done
+
+if [[ "$package_count" -eq 0 ]]; then
+  echo "::error::No projects were packaged (projects input: '$PROJECTS')." >&2
+  exit 1
+fi
+
+echo "Built $package_count Debian package(s) in $output_dir."
+echo "package-count=$package_count" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -231,8 +231,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    outputs:
-      has-nuget-packages: ${{ steps.detect-nuget-packages.outputs.has-nuget-packages }}
     steps:
       - name: Azure Login
         uses: azure/login@v3
@@ -301,10 +299,6 @@ jobs:
           dotnet tool install -g Skyline.DataMiner.CICD.Tools.NuGetValidateSkylineSpecifications --version 3.*
 
           if [[ "$HAS_DM_PROJECTS" == "true" ]]; then
-            if [[ "$GH_ACTOR" != "dependabot[bot]" ]]; then
-              dotnet tool install Skyline.DataMiner.CICD.Tools.Sbom --global --version 1.*
-            fi
-
             dotnet tool install Skyline.DataMiner.CICD.Tools.NuGetChangeVersion --global --version 3.*
           fi
         shell: bash
@@ -325,6 +319,7 @@ jobs:
         uses: SkylineCommunications/_ReusableWorkflows/.github/actions/remove-wix-projects@main
         with:
           solution-path: ${{ needs.discover_projects.outputs.solution-path }}
+
       - name: Update msbuild-sdks in global.json
         if: needs.discover_projects.outputs.has-dataminer-projects == 'true'
         uses: SkylineCommunications/_ReusableWorkflows/.github/actions/update-global-json-sdks@main
@@ -428,31 +423,22 @@ jobs:
 
       - name: Build
         env:
-          OVERRIDE_CATALOG_DOWNLOAD_TOKEN: ${{ secrets.OVERRIDE_CATALOG_DOWNLOAD_TOKEN }}
           SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
           VERSION: ${{ needs.determine_version.outputs.version }}
           CONFIGURATION: ${{ inputs.configuration }}
           DEBUG_FLAG: ${{ inputs.debug }}
-          REF_TYPE: ${{ github.ref_type }}
         run: |
-          # Transitional (until the Windows packaging job exists): tag builds still produce
-          # the NuGet/DataMiner packages here for the downstream sign/upload jobs; branch
-          # and PR builds are validation-only, so packaging is off (also keeps the catalog
-          # download token out of fork CI, which has no secrets).
-          packaging_flags=()
-          if [[ "$REF_TYPE" != "tag" ]]; then
-            packaging_flags+=( -p:GeneratePackageOnBuild=false -p:GenerateDataMinerPackage=false )
-          fi
+          # Validation-only build: packaging is off — the shippable artifacts (NuGet,
+          # .dmapp, MSI, .deb) are produced and signed by the tag-only packaging jobs.
+          # This also keeps the catalog download token out of fork CI (no secrets there).
           dotnet build "$SOLUTION_PATH" \
             -p:Version="$VERSION" \
             -p:PackageVersion="$VERSION" \
             -p:DefineConstants="DCFv1%3BDBInfo%3BALARM_SQUASHING" \
             --configuration "$CONFIGURATION" \
-            -p:CatalogPublishKeyName="DATAMINER_TOKEN" \
-            -p:CatalogDefaultDownloadKeyName="OVERRIDE_CATALOG_DOWNLOAD_TOKEN" \
             -p:SkylineDataMinerSdkDebug="$DEBUG_FLAG" \
-            -p:PackageOutputPath="${GITHUB_WORKSPACE}/_NuGetOutput" \
-            "${packaging_flags[@]}"
+            -p:GeneratePackageOnBuild=false \
+            -p:GenerateDataMinerPackage=false
 
       # ──────────────────────────────────────────────────────────────
       # D. Test & Quality Gate
@@ -493,37 +479,190 @@ jobs:
           sonarcloud-project-name: ${{ github.actor != 'dependabot[bot]' && needs.check_oidc.outputs.is-fork != 'true' && inputs.sonarcloud-project-name || '' }}
           dependabot-bypass: ${{ github.actor == 'dependabot[bot]' }}
 
-      # ──────────────────────────────────────────────────────────────
-      # E. Artifacts & Outputs
-      # ──────────────────────────────────────────────────────────────
+  # ════════════════════════════════════════════════════════════════
+  # Ubuntu packaging (tag only): one .deb per project in dxm-projects-ubuntu
+  # ════════════════════════════════════════════════════════════════
 
-      - name: Detect NuGet packages
-        if: github.actor != 'dependabot[bot]'
-        id: detect-nuget-packages
+  package_ubuntu:
+    name: Package Ubuntu Services
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag' && needs.discover_projects.outputs.has-ubuntu-dxm == 'true'
+    needs: [ci, check_oidc, discover_projects, determine_version]
+    steps:
+      - name: Azure Login
+        uses: azure/login@v3
+        if: needs.check_oidc.outputs.use-oidc == 'true'
+        with:
+          client-id: ${{ needs.check_oidc.outputs.client-id }}
+          tenant-id: ${{ needs.check_oidc.outputs.tenant-id }}
+          subscription-id: ${{ needs.check_oidc.outputs.subscription-id }}
+
+      - name: Load secrets
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/load-secrets@main
+        with:
+          use-oidc: ${{ needs.check_oidc.outputs.use-oidc }}
+          secret-names: |
+            azure-token
+          overrides: |
+            AZURE_TOKEN=${{ secrets.AZURE_TOKEN }}
+
+      - uses: actions/checkout@v7
+
+      - name: Setup NuGet sources
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/setup-nuget-sources@main
+        with:
+          repository-owner: ${{ github.repository_owner }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          azure-token: ${{ env.AZURE_TOKEN }}
+
+      - name: Install dataminer-sbom
+        if: ${{ !contains(github.ref_name, '-') }}
+        run: dotnet tool install Skyline.DataMiner.CICD.Tools.Sbom --global --version 1.*
+        shell: bash
+
+      - name: Build Debian packages
+        id: package-debian
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/package-debian@DxMSupport
+        with:
+          projects: ${{ inputs.dxm-projects-ubuntu }}
+          version: ${{ needs.determine_version.outputs.version }}
+          generate-sbom: ${{ !contains(github.ref_name, '-') }}
+          configuration: ${{ inputs.configuration }}
+          output-directory: output
+
+      - name: Upload Debian packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: debian-package
+          path: output/*.deb
+
+  # ════════════════════════════════════════════════════════════════
+  # Windows packaging & signing (tag only): build all shippable artifacts and
+  # sign everything in one place — DLL/EXE → WiX rebuild → MSI → NuGet → dmapp.
+  # The upload jobs below only consume the signed artifacts produced here.
+  # (Windows required for NuGet signing: https://github.com/dotnet/runtime/issues/48794)
+  # ════════════════════════════════════════════════════════════════
+
+  package_windows:
+    name: Package & Sign (Windows)
+    runs-on: windows-latest
+    if: github.ref_type == 'tag' && github.actor != 'dependabot[bot]'
+    needs: [ci, check_oidc, discover_projects, determine_version]
+    outputs:
+      has-nuget-packages: ${{ steps.detect-artifacts.outputs.has-nuget-packages }}
+      has-dataminer-packages: ${{ steps.detect-artifacts.outputs.has-dataminer-packages }}
+      has-msi: ${{ steps.detect-artifacts.outputs.has-msi }}
+    steps:
+      - name: Azure Login
+        uses: azure/login@v3
+        if: needs.check_oidc.outputs.use-oidc == 'true'
+        with:
+          client-id: ${{ needs.check_oidc.outputs.client-id }}
+          tenant-id: ${{ needs.check_oidc.outputs.tenant-id }}
+          subscription-id: ${{ needs.check_oidc.outputs.subscription-id }}
+
+      - name: Load secrets
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/load-secrets@main
+        with:
+          use-oidc: ${{ needs.check_oidc.outputs.use-oidc }}
+          secret-names: |
+            azure-token
+            signing-client-id
+            signing-client-secret
+            signing-tenant-id
+            signing-key-vault-certificate
+            signing-key-vault-url
+            ${{ needs.discover_projects.outputs.has-dataminer-projects == 'true' && 'dataminer-token' || '' }}
+          overrides: |
+            AZURE_TOKEN=${{ secrets.AZURE_TOKEN }}
+            DATAMINER_TOKEN=${{ secrets.DATAMINER_TOKEN }}
+
+      - name: Enable long paths
+        run: git config --global core.longpaths true
+        shell: bash
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup NuGet sources
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/setup-nuget-sources@main
+        with:
+          repository-owner: ${{ github.repository_owner }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          azure-token: ${{ env.AZURE_TOKEN }}
+
+      - name: Install .NET tools
+        env:
+          HAS_DM_PROJECTS: ${{ needs.discover_projects.outputs.has-dataminer-projects }}
+          HAS_WIX_PROJECTS: ${{ needs.discover_projects.outputs.has-wix-projects }}
         run: |
-          if [ -d "_NuGetOutput" ]; then
-            nuget_count=$(find _NuGetOutput -name "*.nupkg" | wc -l)
-          else
-            nuget_count=0
+          dotnet tool install sign --global --prerelease
+
+          if [[ "$HAS_DM_PROJECTS" == "true" || "$HAS_WIX_PROJECTS" == "true" ]]; then
+            dotnet tool install Skyline.DataMiner.CICD.Tools.Sbom --global --version 1.*
           fi
-          if [ "$nuget_count" -gt 0 ]; then
-            echo "Found $nuget_count NuGet package(s)"
-            echo "has-nuget-packages=true" >> $GITHUB_OUTPUT
-          else
-            echo "No NuGet packages found"
-            echo "has-nuget-packages=false" >> $GITHUB_OUTPUT
+
+          if [[ "$HAS_DM_PROJECTS" == "true" ]]; then
+            dotnet tool install Skyline.DataMiner.CICD.Tools.NuGetChangeVersion --global --version 3.*
+            dotnet tool install Skyline.DataMiner.CICD.Tools.PackageSign --global --version 2.*
+          fi
+
+          if [[ "$HAS_WIX_PROJECTS" == "true" ]]; then
+            dotnet tool install Skyline.DataMiner.Utils.Tools.WiXFileInjector --global
           fi
         shell: bash
 
-      - name: Upload NuGet packages
-        if: github.actor != 'dependabot[bot]' && steps.detect-nuget-packages.outputs.has-nuget-packages == 'true'
-        uses: actions/upload-artifact@v7
+      - name: Update msbuild-sdks in global.json
+        if: needs.discover_projects.outputs.has-dataminer-projects == 'true'
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/update-global-json-sdks@main
+
+      - name: Update Skyline.DataMiner.Core.AppPackageInstaller
+        if: needs.discover_projects.outputs.has-dataminer-projects == 'true'
+        env:
+          SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
+        run: NuGetChangeVersion --solution-filepath "$SOLUTION_PATH" --nuget-name Skyline.DataMiner.Core.AppPackageInstaller --nuget-version $VERSION_APPPACKAGEINSTALLER
+        shell: bash
+
+      - name: Apply catalog identifiers
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/apply-catalog-identifiers@main
         with:
-          name: NugetPackages
-          path: _NuGetOutput/*.nupkg
+          mappings: ${{ inputs.override-catalog-identifiers }}
+
+      - name: Apply source_code_url to manifest
+        if: needs.discover_projects.outputs.has-dataminer-projects == 'true'
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/apply-source-code-url@main
+        with:
+          repository: ${{ github.repository }}
+
+      - name: Build all artifacts (packaging on, WiX included)
+        env:
+          OVERRIDE_CATALOG_DOWNLOAD_TOKEN: ${{ secrets.OVERRIDE_CATALOG_DOWNLOAD_TOKEN }}
+          SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
+          VERSION: ${{ needs.determine_version.outputs.version }}
+          NUMERIC_VERSION: ${{ needs.determine_version.outputs.numeric-version }}
+          CONFIGURATION: ${{ inputs.configuration }}
+          DEBUG_FLAG: ${{ inputs.debug }}
+        run: |
+          # NuGet/DataMiner packaging uses the full (suffix-bearing) version; assemblies and
+          # the WiX MSI ProductVersion use the strict 4-field numeric version (WiX projects
+          # reference it as $(ProductVersion) in <Package Version="...">).
+          dotnet build "$SOLUTION_PATH" \
+            -p:Version="$VERSION" \
+            -p:PackageVersion="$VERSION" \
+            -p:AssemblyVersion="$NUMERIC_VERSION" \
+            -p:FileVersion="$NUMERIC_VERSION" \
+            -p:ProductVersion="$NUMERIC_VERSION" \
+            -p:DefineConstants="DCFv1%3BDBInfo%3BALARM_SQUASHING" \
+            --configuration "$CONFIGURATION" \
+            -p:CatalogPublishKeyName="DATAMINER_TOKEN" \
+            -p:CatalogDefaultDownloadKeyName="OVERRIDE_CATALOG_DOWNLOAD_TOKEN" \
+            -p:SkylineDataMinerSdkDebug="$DEBUG_FLAG" \
+            -p:PackageOutputPath="${GITHUB_WORKSPACE}/_NuGetOutput"
+        shell: bash
 
       - name: Create package name
-        if: github.actor != 'dependabot[bot]' && needs.discover_projects.outputs.has-dataminer-projects == 'true'
+        if: needs.discover_projects.outputs.has-dataminer-projects == 'true'
         id: packageName
         env:
           REPO: ${{ github.repository }}
@@ -533,8 +672,8 @@ jobs:
           echo "name=$safeName" >> $env:GITHUB_OUTPUT
         shell: pwsh
 
-      - name: Generate SBOM file
-        if: github.actor != 'dependabot[bot]' && needs.discover_projects.outputs.has-dataminer-projects == 'true'
+      - name: Add SBOM to DataMiner packages
+        if: needs.discover_projects.outputs.has-dataminer-projects == 'true'
         env:
           SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
           PACKAGE_NAME: ${{ steps.packageName.outputs.name }}
@@ -551,12 +690,174 @@ jobs:
               --package-supplier "Skyline Communications" \
               --debug "$DEBUG_FLAG"
           done
+        shell: bash
 
-      - name: Upload DataMiner packages
-        if: github.actor != 'dependabot[bot]' && needs.discover_projects.outputs.has-dataminer-projects == 'true'
+      - name: Generate SBOM files for WiX installers
+        if: needs.discover_projects.outputs.has-wix-projects == 'true' && !contains(github.ref_name, '-')
+        env:
+          PACKAGE_VERSION: ${{ needs.determine_version.outputs.version }}
+        run: |
+          dataminer-sbom generate \
+            --solution-path "$GITHUB_WORKSPACE" \
+            --package-version "$PACKAGE_VERSION" \
+            --package-supplier "Skyline Communications" \
+            --output "$GITHUB_WORKSPACE/SBOM"
+        shell: bash
+
+      - name: Inject SBOM into WiX projects and rebuild
+        if: needs.discover_projects.outputs.has-wix-projects == 'true' && !contains(github.ref_name, '-')
+        env:
+          SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
+          VERSION: ${{ needs.determine_version.outputs.version }}
+          NUMERIC_VERSION: ${{ needs.determine_version.outputs.numeric-version }}
+          CONFIGURATION: ${{ inputs.configuration }}
+        run: |
+          $wixProjectDirs = dotnet sln "$env:SOLUTION_PATH" list | Select-String '\.wixproj' | ForEach-Object { Split-Path -Path $_.ToString().Trim() -Parent }
+          foreach ($wixProjectDir in $wixProjectDirs) {
+            add-file --WixProjDirectory "$wixProjectDir" --includeFilesDirectory "$env:GITHUB_WORKSPACE/SBOM"
+          }
+          # Rebuild so the MSI contains the SBOM.
+          dotnet build "$env:SOLUTION_PATH" `
+            -p:Version="$env:VERSION" `
+            -p:PackageVersion="$env:VERSION" `
+            -p:AssemblyVersion="$env:NUMERIC_VERSION" `
+            -p:FileVersion="$env:NUMERIC_VERSION" `
+            -p:ProductVersion="$env:NUMERIC_VERSION" `
+            -p:GeneratePackageOnBuild=false `
+            -p:GenerateDataMinerPackage=false `
+            --configuration "$env:CONFIGURATION"
+        shell: pwsh
+
+      - name: Sign assemblies (before the MSI is rebuilt)
+        if: needs.check_oidc.outputs.use-oidc == 'true' && needs.discover_projects.outputs.has-wix-projects == 'true'
+        env:
+          AZURE_TENANT_ID: ${{ env.SIGNING_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ env.SIGNING_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ env.SIGNING_CLIENT_SECRET }}
+        run: |
+          # In-place Authenticode signing (no --output) so the WiX rebuild below
+          # bundles the signed binaries into the MSI. Two invocations on purpose:
+          # brace patterns like *.{dll,exe} are NOT expanded (bash doesn't expand
+          # braces inside quotes, and the sign tool's globber has no brace support).
+          for pattern in "**/bin/**/*.dll" "**/bin/**/*.exe"; do
+            sign code azure-key-vault "$pattern" \
+              --publisher-name "Skyline Communications" \
+              --description "Skyline Signing" \
+              --description-url "https://www.skyline.be/" \
+              --azure-key-vault-certificate "$SIGNING_KEY_VAULT_CERTIFICATE" \
+              --azure-key-vault-url "$SIGNING_KEY_VAULT_URL"
+          done
+        shell: bash
+
+      - name: Rebuild WiX projects with signed binaries
+        if: needs.check_oidc.outputs.use-oidc == 'true' && needs.discover_projects.outputs.has-wix-projects == 'true'
+        env:
+          SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
+          VERSION: ${{ needs.determine_version.outputs.version }}
+          NUMERIC_VERSION: ${{ needs.determine_version.outputs.numeric-version }}
+          CONFIGURATION: ${{ inputs.configuration }}
+        run: |
+          # Rebuild ONLY the WiX projects so the MSI is built from the signed DLLs/EXEs.
+          # BuildProjectReferences=false keeps the referenced projects from being
+          # recompiled (which would overwrite the signatures).
+          $solutionDir = Split-Path "$env:SOLUTION_PATH" -Parent
+          $wixProjects = dotnet sln "$env:SOLUTION_PATH" list | Select-String '\.wixproj' | ForEach-Object { $_.ToString().Trim() }
+          foreach ($wixProject in $wixProjects) {
+            dotnet build (Join-Path $solutionDir ($wixProject -replace '\\', '/')) `
+              -p:Version="$env:VERSION" `
+              -p:ProductVersion="$env:NUMERIC_VERSION" `
+              -p:BuildProjectReferences=false `
+              --configuration "$env:CONFIGURATION"
+          }
+        shell: pwsh
+
+      - name: Sign installers
+        if: needs.check_oidc.outputs.use-oidc == 'true' && needs.discover_projects.outputs.has-wix-projects == 'true'
+        env:
+          AZURE_TENANT_ID: ${{ env.SIGNING_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ env.SIGNING_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ env.SIGNING_CLIENT_SECRET }}
+        run: |
+          sign code azure-key-vault "**/bin/**/*.msi" \
+            --publisher-name "Skyline Communications" \
+            --description "Skyline Signing" \
+            --description-url "https://www.skyline.be/" \
+            --azure-key-vault-certificate "$SIGNING_KEY_VAULT_CERTIFICATE" \
+            --azure-key-vault-url "$SIGNING_KEY_VAULT_URL" \
+            --output "_SignedInstallers"
+        shell: bash
+
+      - name: Sign NuGet packages
+        if: needs.check_oidc.outputs.use-oidc == 'true'
+        env:
+          AZURE_TENANT_ID: ${{ env.SIGNING_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ env.SIGNING_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ env.SIGNING_CLIENT_SECRET }}
+        run: |
+          if compgen -G "_NuGetOutput/*.nupkg" > /dev/null; then
+            sign code azure-key-vault "_NuGetOutput/**/*.nupkg" \
+              --publisher-name "Skyline Communications" \
+              --description "Skyline Signing" \
+              --description-url "https://www.skyline.be/" \
+              --azure-key-vault-certificate "$SIGNING_KEY_VAULT_CERTIFICATE" \
+              --azure-key-vault-url "$SIGNING_KEY_VAULT_URL" \
+              --output "_SignedNuGetResults"
+          else
+            echo "No NuGet packages to sign."
+          fi
+        shell: bash
+
+      - name: Sign DataMiner packages
+        if: needs.check_oidc.outputs.use-oidc == 'true' && needs.discover_projects.outputs.has-dataminer-projects == 'true'
+        env:
+          AZURE_TENANT_ID: ${{ env.SIGNING_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ env.SIGNING_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ env.SIGNING_CLIENT_SECRET }}
+          AZURE_KEY_VAULT_URL: ${{ env.SIGNING_KEY_VAULT_URL }}
+          AZURE_KEY_VAULT_CERTIFICATE: ${{ env.SIGNING_KEY_VAULT_CERTIFICATE }}
+          DEBUG_FLAG: ${{ inputs.debug }}
+        run: |
+          dataminer-package-signature sign dmapp `
+            --package-location "$env:GITHUB_WORKSPACE" `
+            --debug $env:DEBUG_FLAG
+        shell: pwsh
+
+      - name: Fall back to unsigned artifacts (signing not available)
+        if: needs.check_oidc.outputs.use-oidc != 'true'
+        run: |
+          echo "::warning::OIDC is not available - artifacts are packaged UNSIGNED."
+          if compgen -G "_NuGetOutput/*.nupkg" > /dev/null; then
+            mkdir -p _SignedNuGetResults
+            cp _NuGetOutput/*.nupkg _SignedNuGetResults/
+          fi
+          mkdir -p _SignedInstallers
+          find . -type f -name '*.msi' -path '*/bin/*' -not -path './_SignedInstallers/*' -exec cp {} _SignedInstallers/ \;
+        shell: bash
+
+      - name: Detect produced artifacts
+        id: detect-artifacts
+        run: |
+          nuget_count=$(find _SignedNuGetResults -name '*.nupkg' 2>/dev/null | wc -l)
+          dm_count=$(find . -type f \( -name '*.dmapp' -o -name '*.dmtest' \) -path '*/bin/*' | wc -l)
+          msi_count=$(find _SignedInstallers -name '*.msi' 2>/dev/null | wc -l)
+          echo "Found $nuget_count NuGet package(s), $dm_count DataMiner package(s), $msi_count MSI installer(s)."
+          echo "has-nuget-packages=$([ "$nuget_count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "has-dataminer-packages=$([ "$dm_count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "has-msi=$([ "$msi_count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Upload signed NuGet packages
+        if: steps.detect-artifacts.outputs.has-nuget-packages == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: DataMiner Installation Packages (${{ inputs.configuration }} ${{ inputs.solution-filter-name }}) unsigned
+          name: SignedNugetPackages
+          path: _SignedNuGetResults
+
+      - name: Upload signed DataMiner packages
+        if: steps.detect-artifacts.outputs.has-dataminer-packages == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: SignedDataMinerPackages
           path: |
             **/bin/${{ inputs.configuration }}/*.dmapp
             **/bin/${{ inputs.configuration }}/*.dmtest
@@ -564,72 +865,13 @@ jobs:
             **/bin/${{ inputs.configuration }}/**/*.dmapp
             **/bin/${{ inputs.configuration }}/**/*.dmtest
             **/bin/${{ inputs.configuration }}/**/*.zip
-        continue-on-error: true
 
-  # ════════════════════════════════════════════════════════════════
-  # NuGet Signing (Windows required: https://github.com/dotnet/runtime/issues/48794)
-  # ════════════════════════════════════════════════════════════════
-
-  sign_nuget:
-    name: Sign NuGet Packages
-    if: needs.ci.outputs.has-nuget-packages == 'true' && github.actor != 'dependabot[bot]'
-    runs-on: windows-latest
-    needs: [ci, check_oidc]
-    steps:
-      - name: Azure Login
-        uses: azure/login@v3
-        if: needs.check_oidc.outputs.use-oidc == 'true'
-        with:
-          client-id: ${{ needs.check_oidc.outputs.client-id }}
-          tenant-id: ${{ needs.check_oidc.outputs.tenant-id }}
-          subscription-id: ${{ needs.check_oidc.outputs.subscription-id }}
-
-      - name: Load signing secrets
-        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/load-secrets@main
-        with:
-          use-oidc: ${{ needs.check_oidc.outputs.use-oidc }}
-          secret-names: |
-            signing-client-id
-            signing-client-secret
-            signing-tenant-id
-            signing-key-vault-certificate
-            signing-key-vault-url
-
-      - name: Download Unsigned NuGet
-        uses: actions/download-artifact@v8
-        with:
-          name: NugetPackages
-          path: _NuGetResults
-
-      - name: Install dotnet sign
-        if: needs.check_oidc.outputs.use-oidc == 'true'
-        run: dotnet tool install sign --global --prerelease
-
-      - name: Sign NuGet Package
-        if: needs.check_oidc.outputs.use-oidc == 'true'
-        env:
-          AZURE_TENANT_ID: ${{ env.SIGNING_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ env.SIGNING_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ env.SIGNING_CLIENT_SECRET }}
-        run: |
-          IFS=$'\n'
-          sign code azure-key-vault "_NuGetResults/**/*.nupkg" --publisher-name "Skyline Communications" --description "Skyline Signing" --description-url "https://www.skyline.be/" --azure-key-vault-certificate "$SIGNING_KEY_VAULT_CERTIFICATE" --azure-key-vault-url "$SIGNING_KEY_VAULT_URL" --output "_SignedNuGetResults"
-          unset IFS
-        shell: bash
-
-      - name: Upload Signed NuGet
-        if: needs.check_oidc.outputs.use-oidc == 'true'
+      - name: Upload signed installers
+        if: steps.detect-artifacts.outputs.has-msi == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: SignedNugetPackages
-          path: "${{ github.workspace }}/_SignedNuGetResults"
-
-      - name: Upload Unsigned NuGet (signing not available)
-        if: needs.check_oidc.outputs.use-oidc != 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          name: SignedNugetPackages
-          path: "${{ github.workspace }}/_NuGetResults"
+          name: SignedInstallers
+          path: _SignedInstallers
 
   # ════════════════════════════════════════════════════════════════
   # NuGet Push (on tag only)
@@ -637,9 +879,9 @@ jobs:
 
   push_nuget:
     name: Push NuGet Packages
-    if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' && needs.package_windows.outputs.has-nuget-packages == 'true'
     runs-on: ubuntu-latest
-    needs: [sign_nuget, check_oidc]
+    needs: [package_windows, check_oidc]
     steps:
       - name: Azure Login
         uses: azure/login@v3
@@ -708,8 +950,8 @@ jobs:
   upload_to_catalog:
     name: Upload to Catalog
     runs-on: windows-latest
-    if: github.ref_type == 'tag' && needs.discover_projects.outputs.has-dataminer-projects == 'true'
-    needs: [ci, check_oidc, discover_projects]
+    if: github.ref_type == 'tag' && needs.discover_projects.outputs.has-dataminer-projects == 'true' && needs.package_windows.outputs.has-dataminer-packages == 'true'
+    needs: [package_windows, check_oidc, discover_projects]
     steps:
       - name: Azure Login
         uses: azure/login@v3
@@ -725,11 +967,6 @@ jobs:
           use-oidc: ${{ needs.check_oidc.outputs.use-oidc }}
           secret-names: |
             dataminer-token
-            signing-client-id
-            signing-client-secret
-            signing-tenant-id
-            signing-key-vault-certificate
-            signing-key-vault-url
           overrides: |
             DATAMINER_TOKEN=${{ secrets.DATAMINER_TOKEN }}
 
@@ -740,10 +977,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download artifact from CI
+      - name: Download signed artifacts
         uses: actions/download-artifact@v8
         with:
-          name: DataMiner Installation Packages (${{ inputs.configuration }} ${{ inputs.solution-filter-name }}) unsigned
+          name: SignedDataMinerPackages
           path: downloaded_artifacts
 
       - name: Restore artifact contents to bin folders
@@ -771,26 +1008,6 @@ jobs:
           Remove-Item -Path $downloadRoot -Recurse -Force
           Write-Output "Cleanup complete."
         shell: pwsh
-
-      - name: Install Tools
-        if: needs.check_oidc.outputs.use-oidc == 'true'
-        run: |
-          dotnet tool install Skyline.DataMiner.CICD.Tools.PackageSign --global --version 2.*
-
-      - name: Sign generated dmapp/dmtest packages
-        if: needs.check_oidc.outputs.use-oidc == 'true'
-        shell: pwsh
-        env:
-          AZURE_TENANT_ID: ${{ env.SIGNING_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ env.SIGNING_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ env.SIGNING_CLIENT_SECRET }}
-          AZURE_KEY_VAULT_URL: ${{ env.SIGNING_KEY_VAULT_URL }}
-          AZURE_KEY_VAULT_CERTIFICATE: ${{ env.SIGNING_KEY_VAULT_CERTIFICATE }}
-          DEBUG_FLAG: ${{ inputs.debug }}
-        run: |
-          dataminer-package-signature sign dmapp `
-            --package-location "$env:GITHUB_WORKSPACE" `
-            --debug $env:DEBUG_FLAG
 
       - name: Find Version Comment
         id: findVersionComment

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -689,7 +689,6 @@ jobs:
             -p:AssemblyVersion="$NUMERIC_VERSION" \
             -p:FileVersion="$NUMERIC_VERSION" \
             -p:ProductVersion="$NUMERIC_VERSION" \
-            -p:DefineConstants="DCFv1%3BDBInfo%3BALARM_SQUASHING" \
             --configuration "$CONFIGURATION" \
             -p:CatalogPublishKeyName="DATAMINER_TOKEN" \
             -p:CatalogDefaultDownloadKeyName="OVERRIDE_CATALOG_DOWNLOAD_TOKEN" \

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -247,6 +247,8 @@ jobs:
           secret-names: |
             azure-token
             sonar-token
+            skylinecommunications-github-token
+            skylinecommunicationscore-github-token
             ${{ needs.discover_projects.outputs.has-dataminer-projects == 'true' && 'dataminer-token' || '' }}
           overrides: |
             AZURE_TOKEN=${{ secrets.AZURE_TOKEN }}
@@ -277,13 +279,24 @@ jobs:
         with:
           packages: mono-complete
       
-      - name: Setup NuGet sources
-        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/setup-nuget-sources@main
+      # Skyline-managed repos register BOTH organizations' GitHub Packages feeds
+      # (cross-org restore needs the Key Vault tokens - the default GITHUB_TOKEN only
+      # reads its own org) + the Skyline Azure feeds. Non-Skyline owners and fork PRs
+      # (no Key Vault) fall back to just their own organization's feed.
+      - name: Setup Skyline NuGet sources
+        if: needs.check_oidc.outputs.is-skyline-managed == 'true'
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/setup-skyline-nuget-sources@main
         with:
-          repository-owner: ${{ github.repository_owner }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          skylinecommunications-github-token: ${{ env.SKYLINECOMMUNICATIONS_GITHUB_TOKEN }}
+          skylinecommunicationscore-github-token: ${{ env.SKYLINECOMMUNICATIONSCORE_GITHUB_TOKEN }}
           azure-token: ${{ env.AZURE_TOKEN }}
-          public-only: ${{ needs.check_oidc.outputs.is-fork }}
+
+      - name: Setup local GitHub NuGet source
+        if: needs.check_oidc.outputs.is-skyline-managed != 'true' || needs.check_oidc.outputs.is-fork == 'true'
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/add-github-nuget-source@main
+        with:
+          organization: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install .NET tools
         env:
@@ -504,17 +517,27 @@ jobs:
           use-oidc: ${{ needs.check_oidc.outputs.use-oidc }}
           secret-names: |
             azure-token
+            skylinecommunications-github-token
+            skylinecommunicationscore-github-token
           overrides: |
             AZURE_TOKEN=${{ secrets.AZURE_TOKEN }}
 
       - uses: actions/checkout@v7
 
-      - name: Setup NuGet sources
-        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/setup-nuget-sources@main
+      - name: Setup Skyline NuGet sources
+        if: needs.check_oidc.outputs.is-skyline-managed == 'true'
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/setup-skyline-nuget-sources@main
         with:
-          repository-owner: ${{ github.repository_owner }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          skylinecommunications-github-token: ${{ env.SKYLINECOMMUNICATIONS_GITHUB_TOKEN }}
+          skylinecommunicationscore-github-token: ${{ env.SKYLINECOMMUNICATIONSCORE_GITHUB_TOKEN }}
           azure-token: ${{ env.AZURE_TOKEN }}
+
+      - name: Setup local GitHub NuGet source
+        if: needs.check_oidc.outputs.is-skyline-managed != 'true'
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/add-github-nuget-source@main
+        with:
+          organization: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dataminer-sbom
         if: github.ref_type == 'tag' && !contains(github.ref_name, '-')
@@ -570,6 +593,8 @@ jobs:
           use-oidc: ${{ needs.check_oidc.outputs.use-oidc }}
           secret-names: |
             azure-token
+            skylinecommunications-github-token
+            skylinecommunicationscore-github-token
             signing-client-id
             signing-client-secret
             signing-tenant-id
@@ -588,12 +613,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup NuGet sources
-        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/setup-nuget-sources@main
+      - name: Setup Skyline NuGet sources
+        if: needs.check_oidc.outputs.is-skyline-managed == 'true'
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/setup-skyline-nuget-sources@main
         with:
-          repository-owner: ${{ github.repository_owner }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          skylinecommunications-github-token: ${{ env.SKYLINECOMMUNICATIONS_GITHUB_TOKEN }}
+          skylinecommunicationscore-github-token: ${{ env.SKYLINECOMMUNICATIONSCORE_GITHUB_TOKEN }}
           azure-token: ${{ env.AZURE_TOKEN }}
+
+      - name: Setup local GitHub NuGet source
+        if: needs.check_oidc.outputs.is-skyline-managed != 'true'
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/add-github-nuget-source@main
+        with:
+          organization: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install .NET tools
         env:

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -689,7 +689,7 @@ jobs:
             -p:AssemblyVersion="$NUMERIC_VERSION" \
             -p:FileVersion="$NUMERIC_VERSION" \
             -p:ProductVersion="$NUMERIC_VERSION" \
-            -p:DefineConstants="DCFv1%3BDBInfo%3BALARM_SQUASHING%3BProductVersion%3D$NUMERIC_VERSION" \
+            -p:DefineConstants="DCFv1%3BDBInfo%3BALARM_SQUASHING" \
             --configuration "$CONFIGURATION" \
             -p:CatalogPublishKeyName="DATAMINER_TOKEN" \
             -p:CatalogDefaultDownloadKeyName="OVERRIDE_CATALOG_DOWNLOAD_TOKEN" \

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -228,6 +228,15 @@ jobs:
       packages: write
       actions: read
       pull-requests: write # required by quality-gate-summary to post the sticky PR comment
+    env:
+      # DataMiner compile constants, exposed as an ENVIRONMENT variable instead of a
+      # -p:DefineConstants global property on purpose: a global property overrides the
+      # DefineConstants a project sets for itself, which breaks WiX projects (they use
+      # DefineConstants for preprocessor variables, e.g. ProductVersion=$(ProductVersion)).
+      # An environment variable is the lowest-precedence source: SDK-style C# projects
+      # append to it ($(DefineConstants);TRACE;NETx_y) so they still get the constants,
+      # while a project that sets its own DefineConstants keeps its value.
+      DefineConstants: DCFv1;DBInfo;ALARM_SQUASHING
     defaults:
       run:
         shell: bash
@@ -444,10 +453,10 @@ jobs:
           # Validation-only build: packaging is off — the shippable artifacts (NuGet,
           # .dmapp, MSI, .deb) are produced and signed by the tag-only packaging jobs.
           # This also keeps the catalog download token out of fork CI (no secrets there).
+          # DefineConstants comes from the job-level env var (see the job's env block).
           dotnet build "$SOLUTION_PATH" \
             -p:Version="$VERSION" \
             -p:PackageVersion="$VERSION" \
-            -p:DefineConstants="DCFv1%3BDBInfo%3BALARM_SQUASHING" \
             --configuration "$CONFIGURATION" \
             -p:SkylineDataMinerSdkDebug="$DEBUG_FLAG" \
             -p:GeneratePackageOnBuild=false \
@@ -574,6 +583,12 @@ jobs:
     runs-on: windows-latest
     if: needs.check_oidc.outputs.is-fork != 'true' && github.actor != 'dependabot[bot]'
     needs: [ci, check_oidc, discover_projects, determine_version]
+    env:
+      # Environment variable instead of -p:DefineConstants — a global property would
+      # override the WiX projects' own DefineConstants (used for preprocessor variables
+      # like ProductVersion=$(ProductVersion)) and break the MSI build. SDK-style C#
+      # projects append to the environment value, so they still get the constants.
+      DefineConstants: DCFv1;DBInfo;ALARM_SQUASHING
     outputs:
       has-nuget-packages: ${{ steps.detect-artifacts.outputs.has-nuget-packages }}
       has-dataminer-packages: ${{ steps.detect-artifacts.outputs.has-dataminer-packages }}
@@ -683,6 +698,8 @@ jobs:
           # NuGet/DataMiner packaging uses the full (suffix-bearing) version; assemblies and
           # the WiX MSI ProductVersion use the strict 4-field numeric version (WiX projects
           # reference it as $(ProductVersion) in <Package Version="...">).
+          # DefineConstants comes from the job-level env var so the WiX projects can keep
+          # their own preprocessor constants (a -p: global would clobber them).
           dotnet build "$SOLUTION_PATH" \
             -p:Version="$VERSION" \
             -p:PackageVersion="$VERSION" \

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -555,7 +555,7 @@ jobs:
 
       - name: Build Debian packages
         id: package-debian
-        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/package-debian@DxMSupport
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/package-debian@main
         with:
           projects: ${{ inputs.dxm-projects-ubuntu }}
           version: ${{ needs.determine_version.outputs.version }}

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -689,7 +689,7 @@ jobs:
             -p:AssemblyVersion="$NUMERIC_VERSION" \
             -p:FileVersion="$NUMERIC_VERSION" \
             -p:ProductVersion="$NUMERIC_VERSION" \
-            -p:DefineConstants="DCFv1%3BDBInfo%3BALARM_SQUASHING" \
+            -p:DefineConstants="DCFv1%3BDBInfo%3BALARM_SQUASHING%3BProductVersion%3D$NUMERIC_VERSION" \
             --configuration "$CONFIGURATION" \
             -p:CatalogPublishKeyName="DATAMINER_TOKEN" \
             -p:CatalogDefaultDownloadKeyName="OVERRIDE_CATALOG_DOWNLOAD_TOKEN" \

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -837,9 +837,18 @@ jobs:
       - name: Detect produced artifacts
         id: detect-artifacts
         run: |
-          nuget_count=$(find _SignedNuGetResults -name '*.nupkg' 2>/dev/null | wc -l)
+          # NOTE: this step runs under `bash -e -o pipefail`; `find` on a missing
+          # directory exits non-zero and would abort the script, so guard each
+          # directory with -d instead of relying on 2>/dev/null.
+          nuget_count=0
+          if [ -d "_SignedNuGetResults" ]; then
+            nuget_count=$(find _SignedNuGetResults -name '*.nupkg' | wc -l)
+          fi
+          msi_count=0
+          if [ -d "_SignedInstallers" ]; then
+            msi_count=$(find _SignedInstallers -name '*.msi' | wc -l)
+          fi
           dm_count=$(find . -type f \( -name '*.dmapp' -o -name '*.dmtest' \) -path '*/bin/*' | wc -l)
-          msi_count=$(find _SignedInstallers -name '*.msi' 2>/dev/null | wc -l)
           echo "Found $nuget_count NuGet package(s), $dm_count DataMiner package(s), $msi_count MSI installer(s)."
           echo "has-nuget-packages=$([ "$nuget_count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "has-dataminer-packages=$([ "$dm_count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -480,13 +480,14 @@ jobs:
           dependabot-bypass: ${{ github.actor == 'dependabot[bot]' }}
 
   # ════════════════════════════════════════════════════════════════
-  # Ubuntu packaging (tag only): one .deb per project in dxm-projects-ubuntu
+  # Ubuntu packaging: one .deb per project in dxm-projects-ubuntu. Runs on every
+  # ref except fork PRs (no secrets) and Dependabot; the .deb release stays tag-only.
   # ════════════════════════════════════════════════════════════════
 
   package_ubuntu:
     name: Package Ubuntu Services
     runs-on: ubuntu-latest
-    if: github.ref_type == 'tag' && needs.discover_projects.outputs.has-ubuntu-dxm == 'true'
+    if: needs.check_oidc.outputs.is-fork != 'true' && github.actor != 'dependabot[bot]' && needs.discover_projects.outputs.has-ubuntu-dxm == 'true'
     needs: [ci, check_oidc, discover_projects, determine_version]
     steps:
       - name: Azure Login
@@ -516,7 +517,7 @@ jobs:
           azure-token: ${{ env.AZURE_TOKEN }}
 
       - name: Install dataminer-sbom
-        if: ${{ !contains(github.ref_name, '-') }}
+        if: github.ref_type == 'tag' && !contains(github.ref_name, '-')
         run: dotnet tool install Skyline.DataMiner.CICD.Tools.Sbom --global --version 1.*
         shell: bash
 
@@ -526,7 +527,7 @@ jobs:
         with:
           projects: ${{ inputs.dxm-projects-ubuntu }}
           version: ${{ needs.determine_version.outputs.version }}
-          generate-sbom: ${{ !contains(github.ref_name, '-') }}
+          generate-sbom: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
           configuration: ${{ inputs.configuration }}
           output-directory: output
 
@@ -537,16 +538,18 @@ jobs:
           path: output/*.deb
 
   # ════════════════════════════════════════════════════════════════
-  # Windows packaging & signing (tag only): build all shippable artifacts and
+  # Windows packaging & signing: build all shippable artifacts and
   # sign everything in one place — DLL/EXE → WiX rebuild → MSI → NuGet → dmapp.
-  # The upload jobs below only consume the signed artifacts produced here.
+  # Runs on every ref except fork PRs (no secrets) and Dependabot, so packaging
+  # problems surface before the release tag; the upload jobs below consume the
+  # signed artifacts and remain tag-only.
   # (Windows required for NuGet signing: https://github.com/dotnet/runtime/issues/48794)
   # ════════════════════════════════════════════════════════════════
 
   package_windows:
     name: Package & Sign (Windows)
     runs-on: windows-latest
-    if: github.ref_type == 'tag' && github.actor != 'dependabot[bot]'
+    if: needs.check_oidc.outputs.is-fork != 'true' && github.actor != 'dependabot[bot]'
     needs: [ci, check_oidc, discover_projects, determine_version]
     outputs:
       has-nuget-packages: ${{ steps.detect-artifacts.outputs.has-nuget-packages }}
@@ -693,7 +696,7 @@ jobs:
         shell: bash
 
       - name: Generate SBOM files for WiX installers
-        if: needs.discover_projects.outputs.has-wix-projects == 'true' && !contains(github.ref_name, '-')
+        if: needs.discover_projects.outputs.has-wix-projects == 'true' && github.ref_type == 'tag' && !contains(github.ref_name, '-')
         env:
           PACKAGE_VERSION: ${{ needs.determine_version.outputs.version }}
         run: |
@@ -705,7 +708,7 @@ jobs:
         shell: bash
 
       - name: Inject SBOM into WiX projects and rebuild
-        if: needs.discover_projects.outputs.has-wix-projects == 'true' && !contains(github.ref_name, '-')
+        if: needs.discover_projects.outputs.has-wix-projects == 'true' && github.ref_type == 'tag' && !contains(github.ref_name, '-')
         env:
           SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
           VERSION: ${{ needs.determine_version.outputs.version }}

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -667,6 +667,56 @@ jobs:
           test "$BRANCH_VERSION" = "0.0.70000"
           test "$BRANCH_NUMERIC" = "0.0.4465.4465"
 
+  package-debian:
+    name: package-debian
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Scaffold two DxM projects with Debian skeletons
+        run: |
+          demo_dir="${RUNNER_TEMP}/deb-demo"
+          mkdir -p "$demo_dir"
+          cd "$demo_dir"
+          for svc in SvcOne SvcTwo; do
+            dotnet new console -n "$svc" -o "$svc"
+            echo '{ "setting": "value" }' > "$svc/appsettings.json"
+            sed -i 's#</Project>#  <ItemGroup><Content Include="appsettings.json" CopyToPublishDirectory="PreserveNewest" /></ItemGroup>\n</Project>#' "$svc/$svc.csproj"
+            mkdir -p "$svc/packaging/Debian/content/DEBIAN"
+            lower=$(echo "$svc" | tr '[:upper:]' '[:lower:]')
+            {
+              echo "Package: $lower"
+              echo "Version: <VERSION>"
+              echo "Architecture: amd64"
+              echo "Maintainer: Skyline Communications <devops@skyline.be>"
+              echo "Description: Test service $svc"
+            } > "$svc/packaging/Debian/content/DEBIAN/control"
+            echo "/etc/skyline-communications/$svc/appsettings.json" > "$svc/packaging/Debian/content/DEBIAN/conffiles"
+          done
+
+      - name: Invoke composite (pre-release version, no SBOM)
+        id: package
+        uses: ./.github/actions/package-debian
+        with:
+          projects: ${{ runner.temp }}/deb-demo/SvcOne, ${{ runner.temp }}/deb-demo/SvcTwo
+          version: 1.2.3-beta.1
+          generate-sbom: 'false'
+          output-directory: deb-output
+
+      - name: Assert Debian packages
+        env:
+          PACKAGE_COUNT: ${{ steps.package.outputs.package-count }}
+        run: |
+          ls -l deb-output
+          test "$PACKAGE_COUNT" = "2"
+          test -f "deb-output/SvcOne_1.2.3~beta.1.deb"
+          test -f "deb-output/SvcTwo_1.2.3~beta.1.deb"
+          version=$(dpkg-deb --field "deb-output/SvcOne_1.2.3~beta.1.deb" Version)
+          test "$version" = "1.2.3~beta.1"
+          dpkg-deb --contents "deb-output/SvcOne_1.2.3~beta.1.deb" | grep -q 'opt/skyline-communications/SvcOne/'
+          dpkg-deb --contents "deb-output/SvcOne_1.2.3~beta.1.deb" | grep -q 'etc/skyline-communications/SvcOne/appsettings.json'
+          dpkg-deb --contents "deb-output/SvcTwo_1.2.3~beta.1.deb" | grep -q 'opt/skyline-communications/SvcTwo/'
+
   remove-wix-projects:
     name: remove-wix-projects
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Restructure the Master Workflow: dedicated packaging & signing jobs

Third slice of the Master Workflow restructure for DxM support (follows #135 `determine-version` and #136 `discover_projects`/WiX + fork-CI). This PR separates **validation** from **packaging/signing/publishing**:

- **`ci`** is now validation-only on every ref: build (packaging off), unit tests, SonarCloud, NuGet-spec validation. It no longer produces or uploads any shippable artifact.
- A new **`package_windows`** job builds **all** artifacts (NuGet, `.dmapp`/`.dmtest`, WiX MSI) and does **all** signing in one place. It runs on **every ref except fork PRs and Dependabot**, so packaging problems surface before the release tag. The `sign_nuget` job is removed.
- A new **`package_ubuntu`** job (same run conditions) builds one `.deb` per project listed in the new `dxm-projects-ubuntu` input, via a new **`package-debian`** composite (port of the Azure `default-cd-linux.yml`).
- All three build jobs now register **both** Skyline organizations' GitHub Packages feeds via the `setup-skyline-nuget-sources` composite (cross-org restore with the Key Vault tokens; the default `GITHUB_TOKEN` only reads its own org). Non-Skyline owners and fork PRs fall back to `add-github-nuget-source` for their own organization only.
- The upload jobs (`push_nuget`, `upload_to_catalog`) stay **tag-only** and become **thin consumers of the signed artifacts** — they no longer sign anything and no longer load signing secrets.

## Job graph

```
validate_trigger → check_oidc / discover_projects / determine_version
                 → ci (validate only; every ref, incl. fork PRs in degraded mode)
                 → package_ubuntu  → debian-package artifact             ┐ every ref except
                 → package_windows → SignedNugetPackages                 ┘ fork PRs / Dependabot
                                   → SignedDataMinerPackages
                                   → SignedInstallers
                     tag only:       SignedNugetPackages     → push_nuget
                                     SignedDataMinerPackages → upload_to_catalog
                                     (installers/.deb        → future upload_dxms)
```

## Changes

### `package_windows` (new)
- Runs on every ref except fork PRs (no secrets available) and Dependabot; branch builds package/sign with the legacy `0.0.<run>` version.
- Mirrors `ci`'s DataMiner setup (global.json SDKs, AppPackageInstaller pin, catalog identifiers, source_code_url), then builds with packaging **on**:
  - `Version` / `PackageVersion` = full SemVer from `determine_version` (suffix-bearing);
  - `AssemblyVersion` / `FileVersion` / `ProductVersion` = strict 4-field `numeric-version`.
- The DataMiner compile constants (`DCFv1;DBInfo;ALARM_SQUASHING`) are supplied as a **job-level environment variable** instead of `-p:DefineConstants`: a `-p:` global property overrides the `DefineConstants` a project sets for itself, which broke WiX projects (they use `DefineConstants` for preprocessor variables such as `ProductVersion=$(ProductVersion)`). SDK-style C# projects append to the environment value, so they still pick up the constants.
- SBOM: `generate-and-add` for `.dmapp`/`.dmtest`; on **full-release tags**, `dataminer-sbom generate` + `WiXFileInjector add-file` + rebuild so the MSI contains the SBOM.
- **Signing order matters** (ported from Azure `default-cd.yml`, extended with payload signing):
  1. in-place Authenticode signing of `**/bin/**` DLLs/EXEs (two glob invocations — the sign tool's globber has no brace support);
  2. rebuild **only** the `.wixproj`s with `-p:BuildProjectReferences=false`, so the MSI bundles the signed binaries without recompiling them;
  3. sign MSIs → `_SignedInstallers`; sign NuGet → `_SignedNuGetResults`; sign `.dmapp` in place.
- Without OIDC the job falls back to **unsigned** artifacts under the same artifact names (with a workflow warning), preserving the old `sign_nuget` fallback behaviour.
- Outputs `has-nuget-packages` / `has-dataminer-packages` / `has-msi`; uploads `SignedNugetPackages`, `SignedDataMinerPackages`, `SignedInstallers`.

### `package_ubuntu` + `package-debian` composite (new)
- Runs on every ref except fork PRs and Dependabot, gated on the new `dxm-projects-ubuntu` input (comma-separated project paths; the project folder name is the Debian service name).
- Each project ships its own skeleton at `<project>/packaging/Debian/content/` and is staged in its **own temp tree**, so multiple `.deb`s per repo never clobber each other.
- Per project: validate skeleton → `dotnet publish -r linux-x64 --self-contained` → SBOM (**full-release tags only**, `usr/share/doc/skyline-communications-<name>`) → conffiles copy → `<VERSION>` substitution → permissions → `dpkg-deb`.
- Version normalisation: `x.y.z-suffix` → `x.y.z~suffix`. Unlike the legacy Azure `sed`, **dots in the suffix are preserved**.
- Uploads a `debian-package` artifact (consumed later by `upload_dxms`).

### `ci` (reverted to validation-only)
- Packaging flags are now always off; the catalog tokens, `_NuGetOutput`, SBOM generation, and both artifact uploads moved to `package_windows`.
- New `dxm-id-file.json` presence check for DxM repos (WiX **or** ubuntu projects) — fail fast, the file is required by the DxM release flow.
- Same `DefineConstants` env-var treatment as `package_windows` (applies to the validation build and the SonarCloud analysis build alike).

### Upload jobs (thin consumers, tag-only)
- `push_nuget`: `needs: package_windows`, gated on its `has-nuget-packages` output; artifact name `SignedNugetPackages` unchanged.
- `upload_to_catalog`: `needs: package_windows`, downloads `SignedDataMinerPackages`; the dmapp signing steps and all signing secrets removed (only `dataminer-token` remains).

## Testing

- New `package-debian` job in *Test composite actions*: scaffolds two console projects with Debian skeletons, builds both `.deb`s, asserts names, the `~`-normalised `Version` field, publish output and conffile contents.
- `actionlint` clean on both workflows; `shellcheck` clean on `package-debian.sh`.
- Downstream pilot (BOOST-DailyRegression-InternalNuGet, tag build): OIDC → Key Vault, versioning (`2026.07.08.250` / numeric `2026.7.8.250`), NuGet build + **signing** all verified green.

## Behavioural changes to be aware of

- **Artifact names on branch/PR builds changed:** `NugetPackages` / `DataMiner Installation Packages (…) unsigned` → `SignedNugetPackages` / `SignedDataMinerPackages` (now produced by `package_windows`, and actually signed).
- **Fork PRs and Dependabot get no packaging at all** (they previously got unsigned packaging in `ci`); they keep build + test.
- **New conventions for WiX projects** (documented in the DxM migration guide): take the MSI version from `$(ProductVersion)` (`<Package Version="$(ProductVersion)">`; the legacy `vs-update-projects` file rewriting is gone), set `<InstallerPlatform>x64</InstallerPlatform>` explicitly (the post-signing rebuild builds the `.wixproj` directly, without the solution's platform mapping — the x86 default causes ICE80), append `$(DefineConstants)` instead of replacing it, and use `$(MSBuildProjectDirectory)`-relative paths instead of `$(SolutionDir)` (not reliably set on direct project builds).
- **`DefineConstants` is no longer forced as a global property:** a project that sets its own `DefineConstants` (WiX preprocessor variables, or a C# project that hard-sets the value instead of appending) now keeps its own value; SDK-style projects that append (the default) are unaffected.
- SBOM generation for MSI/`.deb` only happens on **full-release tags** (pre-release tags and branch builds skip it).

## Pre-merge checklist

- [x] Verify a tag build on a NuGet-only pilot repo (build + versioning + NuGet signing verified; detect-artifacts fix `2a6733a`).
- [x] Verify a branch/PR build end-to-end (packaging now runs there too — `9bfd247`).
- [x] Verify the WiX flow on a pilot DxM repo: `$(ProductVersion)` convention, in-place DLL/EXE signing, `BuildProjectReferences=false` incremental rebuild (must not recompile over signatures).
- [x] Flip `package-debian@DxMSupport` back to `@main` (branch ref was for pre-merge testing only — `4011c92`).

