### PR TITLE
Set Workflow-Repo-Type automatically in workflows

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -46,6 +46,7 @@ Usage examples in each action README are sourced from the master workflows in
 | `apply-catalog-identifiers` | Rewrites manifest `id:` fields from mapping input. | [apply-catalog-identifiers/README.md](apply-catalog-identifiers/README.md) |
 | `compute-next-version` | Computes the next SemVer version from the latest final tag + Change-Type bump. | [compute-next-version/README.md](compute-next-version/README.md) |
 | `determine-version` | Determines the canonical build version (`version` + 4-field `numeric-version`) from the git ref. | [determine-version/README.md](determine-version/README.md) |
+| `set-repo-type` | Writes the enterprise `Workflow-Repo-Type` custom property (idempotent read-before-write). | [set-repo-type/README.md](set-repo-type/README.md) |
 | `remove-wix-projects` | Strips WiX projects from a solution for cross-platform CI builds. | [remove-wix-projects/README.md](remove-wix-projects/README.md) |
 | `package-debian` | Builds a `.deb` per DxM project from per-project Debian skeletons. | [package-debian/README.md](package-debian/README.md) |
 | `apply-source-code-url` | Fills empty `source_code_url:` fields in catalog manifests. | [apply-source-code-url/README.md](apply-source-code-url/README.md) |

--- a/.github/actions/set-repo-type/README.md
+++ b/.github/actions/set-repo-type/README.md
@@ -29,8 +29,13 @@ more than one type at once (e.g. `["DxM","NuGet"]`).
 
 Writing custom-property **values** is privileged — the default `GITHUB_TOKEN` returns `404`. The
 token's user must be an **organization owner** of the repo's org, and the token needs the classic
-**`repo`** scope (`admin:org` is not required). Calls the per-repo endpoint
-`GET`/`PATCH /repos/{owner}/{repo}/properties/values`.
+**`repo`** scope (`admin:org` is not required). A token that is not an org owner of that org gets a
+`404` on the write (GitHub hides the resource rather than returning `403`), even though it can still
+`GET` the values.
+
+Reads use the per-repo `GET /repos/{owner}/{repo}/properties/values`. Writes try the per-repo
+`PATCH /repos/{owner}/{repo}/properties/values` first and, on any error, fall back to the org-level
+`PATCH /orgs/{org}/properties/values` (targeting the single repo by name) as a safety net.
 
 ## Usage
 

--- a/.github/actions/set-repo-type/README.md
+++ b/.github/actions/set-repo-type/README.md
@@ -1,0 +1,65 @@
+# set-repo-type
+
+Writes the **enterprise custom repository property `Workflow-Repo-Type`** on the repository the
+workflow runs in, so the governance signal that drives the conditional rulesets stays in sync with
+what the repo actually builds — instead of being set by hand at repo creation.
+
+`Workflow-Repo-Type` is a **multi-select** property, so its value is an **array** and a repo can be
+more than one type at once (e.g. `["DxM","NuGet"]`).
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | :--: | --- | --- |
+| `repo-types` | yes | — | The value(s) to set — a JSON array (`["DxM","NuGet"]`) or comma-separated list (`DxM,NuGet`) of `DxM` / `NuGet` / `Connector` / `AppPackage`. An empty value leaves the property unchanged. |
+| `token` | yes | — | An **organization-owner** token with the **`repo`** scope (the OIDC-gated Key Vault classic PAT `reusable-workflow-token`). The default `GITHUB_TOKEN` **cannot** write custom-property values. |
+| `property-name` | no | `Workflow-Repo-Type` | The custom property to write. |
+
+## Behaviour
+
+- **Read-before-write (idempotent):** the action first `GET`s the current property value, compares it
+  to the computed set (order-insensitive), and only `PATCH`es when they differ — no churn in the
+  audit log on a no-op run.
+- **Empty set leaves the value:** when `repo-types` is empty (no type detected), the current value is
+  left untouched rather than cleared.
+- **Normalisation:** input is matched case-insensitively, de-duplicated, and written in the canonical
+  order `DxM, NuGet, Connector, AppPackage`. An unknown value fails the action with a clear error.
+
+## Permission
+
+Writing custom-property **values** is privileged — the default `GITHUB_TOKEN` returns `404`. The
+token's user must be an **organization owner** of the repo's org, and the token needs the classic
+**`repo`** scope (`admin:org` is not required). Calls the per-repo endpoint
+`GET`/`PATCH /repos/{owner}/{repo}/properties/values`.
+
+## Usage
+
+```yaml
+# Connector Master Workflow — always a connector repo:
+- uses: SkylineCommunications/_ReusableWorkflows/.github/actions/set-repo-type@main
+  with:
+    repo-types: Connector
+    token: ${{ steps.load-secrets.outputs.reusable-workflow-token }}
+
+# Master Workflow — derived from discover_projects (may be several):
+- uses: SkylineCommunications/_ReusableWorkflows/.github/actions/set-repo-type@main
+  with:
+    repo-types: ${{ steps.map-repo-types.outputs.repo-types }}   # e.g. "DxM,NuGet"
+    token: ${{ steps.load-secrets.outputs.reusable-workflow-token }}
+```
+
+Run the write only on the **default branch** so feature branches never flip a repo's governance type:
+
+```yaml
+if: github.ref_name == github.event.repository.default_branch
+```
+
+## Testing
+
+`test.ps1` dot-sources `set-repo-type.ps1` and unit-tests the pure helpers
+(`ConvertTo-RepoTypeSet`, `Test-RepoTypeSetEqual`, `ConvertTo-PropertyPatchBody`) without any API
+calls:
+
+```pwsh
+pwsh -NoProfile -File ./test.ps1
+```

--- a/.github/actions/set-repo-type/action.yml
+++ b/.github/actions/set-repo-type/action.yml
@@ -1,0 +1,40 @@
+name: Set repo type
+description: >
+  Writes the enterprise custom repository property `Workflow-Repo-Type`
+  (multi-select) on the repository the workflow runs in, so the governance
+  signal driving the conditional rulesets stays in sync with what the repo
+  actually builds. Reads the current value first and only PATCHes when the
+  computed set differs (idempotent); an empty set leaves the current value
+  untouched. Requires an org-owner token with the `repo` scope — the default
+  `GITHUB_TOKEN` cannot write custom-property values.
+
+inputs:
+  repo-types:
+    description: >
+      The value(s) to set — a JSON array (e.g. `["DxM","NuGet"]`) or a
+      comma-separated list (e.g. `DxM,NuGet`) of `DxM` / `NuGet` /
+      `Connector` / `AppPackage`. An empty value leaves the property unchanged.
+    required: true
+  token:
+    description: >
+      An organization-owner token with the `repo` scope (the OIDC-gated Key
+      Vault classic PAT `reusable-workflow-token`) — NOT the default
+      `GITHUB_TOKEN`, which cannot write custom-property values.
+    required: true
+  property-name:
+    description: The custom property to write.
+    required: false
+    default: Workflow-Repo-Type
+
+runs:
+  using: composite
+  steps:
+    - name: Set repo type
+      shell: pwsh
+      env:
+        REPO_TYPES: ${{ inputs.repo-types }}
+        TOKEN: ${{ inputs.token }}
+        PROPERTY_NAME: ${{ inputs.property-name }}
+        REPOSITORY: ${{ github.repository }}
+        GITHUB_API_URL: ${{ github.api_url }}
+      run: '& "$env:GITHUB_ACTION_PATH/set-repo-type.ps1"'

--- a/.github/actions/set-repo-type/set-repo-type.ps1
+++ b/.github/actions/set-repo-type/set-repo-type.ps1
@@ -79,6 +79,29 @@ function ConvertTo-PropertyPatchBody {
     return ($payload | ConvertTo-Json -Depth 5)
 }
 
+# Build the PATCH body for the ORG-LEVEL custom-property-values endpoint, which sets the property on a
+# named set of repos. This is the fallback for an enterprise property whose `values_editable_by` is
+# `org_actors`: the per-repo endpoint returns 404 for such a property, but an org owner can set it here.
+function ConvertTo-OrgPropertyPatchBody {
+    param(
+        [Parameter(Mandatory)][string]$PropertyName,
+        [Parameter(Mandatory)][string[]]$Value,
+        [Parameter(Mandatory)][string]$RepositoryName
+    )
+
+    $payload = [ordered]@{
+        repository_names = @($RepositoryName)
+        properties       = @(
+            [ordered]@{
+                property_name = $PropertyName
+                value         = @($Value)
+            }
+        )
+    }
+
+    return ($payload | ConvertTo-Json -Depth 5)
+}
+
 function Invoke-Main {
     if ([string]::IsNullOrWhiteSpace($env:REPOSITORY)) {
         throw 'REPOSITORY must be set (owner/repo).'
@@ -118,9 +141,27 @@ function Invoke-Main {
     }
 
     Write-Host "Updating '$propertyName' from [$($currentValue -join ', ')] to [$($desired -join ', ')] ..."
-    $body = ConvertTo-PropertyPatchBody -PropertyName $propertyName -Value $desired
-    Invoke-RestMethod -Method Patch -Uri $endpoint -Headers $headers -Body $body -ContentType 'application/json' | Out-Null
-    Write-Host "Updated '$propertyName'."
+
+    # Try the per-repo endpoint first (works when the token's user is an org owner). On any error fall
+    # back to the org-level endpoint as a safety net. A 404 here usually means the token's user is not
+    # an org owner of this repo's org (GitHub hides the resource rather than returning 403).
+    $repoBody = ConvertTo-PropertyPatchBody -PropertyName $propertyName -Value $desired
+    try {
+        Invoke-RestMethod -Method Patch -Uri $endpoint -Headers $headers -Body $repoBody -ContentType 'application/json' | Out-Null
+        Write-Host "Updated '$propertyName' via the per-repo endpoint."
+        return
+    }
+    catch {
+        $repoError = $_.Exception.Message
+        Write-Host "Per-repo endpoint did not accept the write ($repoError); trying the org-level endpoint ..."
+    }
+
+    $owner = ($env:REPOSITORY -split '/', 2)[0]
+    $repositoryName = ($env:REPOSITORY -split '/', 2)[1]
+    $orgEndpoint = "$apiUrl/orgs/$owner/properties/values"
+    $orgBody = ConvertTo-OrgPropertyPatchBody -PropertyName $propertyName -Value $desired -RepositoryName $repositoryName
+    Invoke-RestMethod -Method Patch -Uri $orgEndpoint -Headers $headers -Body $orgBody -ContentType 'application/json' | Out-Null
+    Write-Host "Updated '$propertyName' via the org-level endpoint."
 }
 
 # Run the network logic only when executed directly; test.ps1 dot-sources this file to unit-test the

--- a/.github/actions/set-repo-type/set-repo-type.ps1
+++ b/.github/actions/set-repo-type/set-repo-type.ps1
@@ -1,0 +1,130 @@
+$ErrorActionPreference = 'Stop'
+
+# The enterprise custom property `Workflow-Repo-Type` is a multi-select whose value is an array.
+# These are the only values it accepts; input is matched case-insensitively and normalised to these.
+$script:AllowedRepoTypes = @('DxM', 'NuGet', 'Connector', 'AppPackage')
+
+# Parse the raw `repo-types` input (a JSON array or a comma-separated list) into a normalised,
+# de-duplicated set of canonical values, ordered by $AllowedRepoTypes for a stable, comparable result.
+# An empty / whitespace input yields an empty set (the caller then leaves the property unchanged).
+function ConvertTo-RepoTypeSet {
+    param([AllowNull()][AllowEmptyString()][string]$Raw)
+
+    if ([string]::IsNullOrWhiteSpace($Raw)) {
+        return @()
+    }
+
+    $trimmed = $Raw.Trim()
+    if ($trimmed.StartsWith('[')) {
+        $tokens = @($trimmed | ConvertFrom-Json)
+    }
+    else {
+        $tokens = $trimmed -split ','
+    }
+
+    $canonicalByLower = @{}
+    foreach ($allowed in $script:AllowedRepoTypes) {
+        $canonicalByLower[$allowed.ToLowerInvariant()] = $allowed
+    }
+
+    $selected = @{}
+    foreach ($token in $tokens) {
+        if ($null -eq $token) { continue }
+        $value = ([string]$token).Trim()
+        if ($value -eq '') { continue }
+
+        $key = $value.ToLowerInvariant()
+        if (-not $canonicalByLower.ContainsKey($key)) {
+            throw "Invalid repo type '$value'. Allowed values: $($script:AllowedRepoTypes -join ', ')."
+        }
+        $selected[$canonicalByLower[$key]] = $true
+    }
+
+    return @($script:AllowedRepoTypes | Where-Object { $selected.ContainsKey($_) })
+}
+
+# Order-insensitive comparison of two value sets, so re-ordering alone never triggers a PATCH.
+function Test-RepoTypeSetEqual {
+    param(
+        [AllowNull()][string[]]$First,
+        [AllowNull()][string[]]$Second
+    )
+
+    $a = @(@($First) | Sort-Object -CaseSensitive)
+    $b = @(@($Second) | Sort-Object -CaseSensitive)
+    if ($a.Count -ne $b.Count) { return $false }
+    for ($i = 0; $i -lt $a.Count; $i++) {
+        if ($a[$i] -ne $b[$i]) { return $false }
+    }
+    return $true
+}
+
+# Build the PATCH body for the per-repo custom-property-values endpoint. `value` is always an array
+# (multi-select) — even for a single element (PowerShell 7 preserves single-element arrays).
+function ConvertTo-PropertyPatchBody {
+    param(
+        [Parameter(Mandatory)][string]$PropertyName,
+        [Parameter(Mandatory)][string[]]$Value
+    )
+
+    $payload = [ordered]@{
+        properties = @(
+            [ordered]@{
+                property_name = $PropertyName
+                value         = @($Value)
+            }
+        )
+    }
+
+    return ($payload | ConvertTo-Json -Depth 5)
+}
+
+function Invoke-Main {
+    if ([string]::IsNullOrWhiteSpace($env:REPOSITORY)) {
+        throw 'REPOSITORY must be set (owner/repo).'
+    }
+    if ([string]::IsNullOrWhiteSpace($env:TOKEN)) {
+        throw 'TOKEN must be set. The default GITHUB_TOKEN cannot write custom-property values.'
+    }
+
+    $propertyName = if ([string]::IsNullOrWhiteSpace($env:PROPERTY_NAME)) { 'Workflow-Repo-Type' } else { $env:PROPERTY_NAME.Trim() }
+    $apiUrl = if ([string]::IsNullOrWhiteSpace($env:GITHUB_API_URL)) { 'https://api.github.com' } else { $env:GITHUB_API_URL.TrimEnd('/') }
+
+    $desired = ConvertTo-RepoTypeSet -Raw $env:REPO_TYPES
+    if ($desired.Count -eq 0) {
+        Write-Host "No repo type detected; leaving '$propertyName' unchanged."
+        return
+    }
+
+    $headers = @{
+        Authorization          = "Bearer $($env:TOKEN)"
+        Accept                 = 'application/vnd.github+json'
+        'X-GitHub-Api-Version' = '2022-11-28'
+    }
+    $endpoint = "$apiUrl/repos/$($env:REPOSITORY)/properties/values"
+
+    # Read-before-write: GET returns [] when no value is set yet, so an unset property reads as empty.
+    Write-Host "Reading current custom property values from $endpoint ..."
+    $current = Invoke-RestMethod -Method Get -Uri $endpoint -Headers $headers
+    $currentEntry = @($current) | Where-Object { $_.property_name -eq $propertyName }
+    $currentValue = @()
+    if ($null -ne $currentEntry -and $null -ne $currentEntry.value) {
+        $currentValue = @($currentEntry.value)
+    }
+
+    if (Test-RepoTypeSetEqual -First $currentValue -Second $desired) {
+        Write-Host "'$propertyName' is already [$($desired -join ', ')]; no update needed."
+        return
+    }
+
+    Write-Host "Updating '$propertyName' from [$($currentValue -join ', ')] to [$($desired -join ', ')] ..."
+    $body = ConvertTo-PropertyPatchBody -PropertyName $propertyName -Value $desired
+    Invoke-RestMethod -Method Patch -Uri $endpoint -Headers $headers -Body $body -ContentType 'application/json' | Out-Null
+    Write-Host "Updated '$propertyName'."
+}
+
+# Run the network logic only when executed directly; test.ps1 dot-sources this file to unit-test the
+# pure helper functions (parsing / comparison / body building) without any API calls.
+if ($MyInvocation.InvocationName -ne '.') {
+    Invoke-Main
+}

--- a/.github/actions/set-repo-type/test.ps1
+++ b/.github/actions/set-repo-type/test.ps1
@@ -1,0 +1,130 @@
+$ErrorActionPreference = 'Stop'
+
+$actionDirectory = Split-Path -Parent $PSCommandPath
+$scriptPath = Join-Path -Path $actionDirectory -ChildPath 'set-repo-type.ps1'
+
+# Dot-source the action script. `InvocationName` becomes '.', so Invoke-Main is NOT run — only the
+# pure helper functions are defined, which is exactly what we unit-test here (no API calls).
+. $scriptPath
+
+$script:failures = 0
+
+function Assert-Equal {
+    param(
+        [AllowNull()][object]$Actual,
+        [AllowNull()][object]$Expected,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    if ($Actual -ne $Expected) {
+        Write-Host "FAIL  ${Label}: expected '${Expected}', got '${Actual}'."
+        $script:failures++
+        return
+    }
+    Write-Host "PASS  $Label"
+}
+
+function Assert-True {
+    param(
+        [bool]$Condition,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    if (-not $Condition) {
+        Write-Host "FAIL  ${Label}: expected condition to be true."
+        $script:failures++
+        return
+    }
+    Write-Host "PASS  $Label"
+}
+
+function Assert-Throws {
+    param(
+        [Parameter(Mandatory)][scriptblock]$Action,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    try {
+        & $Action | Out-Null
+        Write-Host "FAIL  ${Label}: expected an exception, none thrown."
+        $script:failures++
+    }
+    catch {
+        Write-Host "PASS  $Label"
+    }
+}
+
+# ---- ConvertTo-RepoTypeSet ------------------------------------------------------------------------
+
+Assert-Equal -Label 'empty string -> empty set' `
+    -Actual ((ConvertTo-RepoTypeSet -Raw '') -join ',') -Expected ''
+
+Assert-Equal -Label 'whitespace -> empty set' `
+    -Actual ((ConvertTo-RepoTypeSet -Raw '   ') -join ',') -Expected ''
+
+Assert-Equal -Label 'single comma value' `
+    -Actual ((ConvertTo-RepoTypeSet -Raw 'Connector') -join ',') -Expected 'Connector'
+
+Assert-Equal -Label 'comma list, canonical order' `
+    -Actual ((ConvertTo-RepoTypeSet -Raw 'NuGet,DxM') -join ',') -Expected 'DxM,NuGet'
+
+Assert-Equal -Label 'comma list with spaces' `
+    -Actual ((ConvertTo-RepoTypeSet -Raw ' DxM , AppPackage ') -join ',') -Expected 'DxM,AppPackage'
+
+Assert-Equal -Label 'JSON array' `
+    -Actual ((ConvertTo-RepoTypeSet -Raw '["DxM","NuGet"]') -join ',') -Expected 'DxM,NuGet'
+
+Assert-Equal -Label 'case-insensitive -> canonical casing' `
+    -Actual ((ConvertTo-RepoTypeSet -Raw 'dxm,NUGET,apppackage') -join ',') -Expected 'DxM,NuGet,AppPackage'
+
+Assert-Equal -Label 'duplicates removed' `
+    -Actual ((ConvertTo-RepoTypeSet -Raw 'DxM,DxM,dxm') -join ',') -Expected 'DxM'
+
+Assert-Equal -Label 'empty tokens ignored' `
+    -Actual ((ConvertTo-RepoTypeSet -Raw 'DxM,,NuGet,') -join ',') -Expected 'DxM,NuGet'
+
+Assert-Equal -Label 'all four, stable canonical order' `
+    -Actual ((ConvertTo-RepoTypeSet -Raw 'AppPackage,Connector,NuGet,DxM') -join ',') -Expected 'DxM,NuGet,Connector,AppPackage'
+
+Assert-Throws -Label 'invalid value throws' -Action { ConvertTo-RepoTypeSet -Raw 'DxM,Bogus' }
+
+# ---- Test-RepoTypeSetEqual ------------------------------------------------------------------------
+
+Assert-True -Label 'equal sets (same order)' `
+    -Condition (Test-RepoTypeSetEqual -First @('DxM', 'NuGet') -Second @('DxM', 'NuGet'))
+
+Assert-True -Label 'equal sets (different order)' `
+    -Condition (Test-RepoTypeSetEqual -First @('NuGet', 'DxM') -Second @('DxM', 'NuGet'))
+
+Assert-True -Label 'both empty are equal' `
+    -Condition (Test-RepoTypeSetEqual -First @() -Second @())
+
+Assert-True -Label 'different length not equal' `
+    -Condition (-not (Test-RepoTypeSetEqual -First @('DxM') -Second @('DxM', 'NuGet')))
+
+Assert-True -Label 'different content not equal' `
+    -Condition (-not (Test-RepoTypeSetEqual -First @('DxM') -Second @('NuGet')))
+
+# ---- ConvertTo-PropertyPatchBody ------------------------------------------------------------------
+
+$singleBody = ConvertTo-PropertyPatchBody -PropertyName 'Workflow-Repo-Type' -Value @('Connector')
+$singleParsed = $singleBody | ConvertFrom-Json
+Assert-Equal -Label 'body property_name' `
+    -Actual $singleParsed.properties[0].property_name -Expected 'Workflow-Repo-Type'
+Assert-True -Label 'single value serialises as JSON array' `
+    -Condition ($singleParsed.properties[0].value -is [array])
+Assert-Equal -Label 'single value content' `
+    -Actual ($singleParsed.properties[0].value -join ',') -Expected 'Connector'
+
+$multiBody = ConvertTo-PropertyPatchBody -PropertyName 'Workflow-Repo-Type' -Value @('DxM', 'NuGet')
+$multiParsed = $multiBody | ConvertFrom-Json
+Assert-Equal -Label 'multi value content' `
+    -Actual ($multiParsed.properties[0].value -join ',') -Expected 'DxM,NuGet'
+
+# ---- Result ---------------------------------------------------------------------------------------
+
+if ($script:failures -gt 0) {
+    throw "$script:failures test case(s) failed."
+}
+
+Write-Host 'All set-repo-type test cases passed.'

--- a/.github/actions/set-repo-type/test.ps1
+++ b/.github/actions/set-repo-type/test.ps1
@@ -121,6 +121,21 @@ $multiParsed = $multiBody | ConvertFrom-Json
 Assert-Equal -Label 'multi value content' `
     -Actual ($multiParsed.properties[0].value -join ',') -Expected 'DxM,NuGet'
 
+# ---- ConvertTo-OrgPropertyPatchBody ---------------------------------------------------------------
+
+$orgBody = ConvertTo-OrgPropertyPatchBody -PropertyName 'Workflow-Repo-Type' -Value @('Connector') -RepositoryName 'MyRepo'
+$orgParsed = $orgBody | ConvertFrom-Json
+Assert-True -Label 'org body repository_names is an array' `
+    -Condition ($orgParsed.repository_names -is [array])
+Assert-Equal -Label 'org body repository_names content' `
+    -Actual ($orgParsed.repository_names -join ',') -Expected 'MyRepo'
+Assert-Equal -Label 'org body property_name' `
+    -Actual $orgParsed.properties[0].property_name -Expected 'Workflow-Repo-Type'
+Assert-True -Label 'org body single value serialises as JSON array' `
+    -Condition ($orgParsed.properties[0].value -is [array])
+Assert-Equal -Label 'org body value content' `
+    -Actual ($orgParsed.properties[0].value -join ',') -Expected 'Connector'
+
 # ---- Result ---------------------------------------------------------------------------------------
 
 if ($script:failures -gt 0) {

--- a/.github/workflows/Connector Master Workflow.yml
+++ b/.github/workflows/Connector Master Workflow.yml
@@ -179,7 +179,7 @@ jobs:
   # Keep the enterprise custom property `Workflow-Repo-Type` in sync: a connector repo is always
   # `Connector`. Runs only on the repository's default branch (feature branches / PRs / tags never
   # flip the governance type) and only for Skyline-managed repos where OIDC (and thus the Key Vault
-  # token) is available. The write identity is the org-owner classic PAT `reusable-workflow-token`;
+  # token) is available. The write identity is the org-owner classic PAT `reusable-workflows-token`;
   # the default GITHUB_TOKEN cannot write it.
   set_repo_type:
     name: Set Repo Type
@@ -205,10 +205,10 @@ jobs:
         with:
           use-oidc: ${{ needs.check_oidc.outputs.use-oidc }}
           secret-names: |
-            reusable-workflow-token
+            reusable-workflows-token
 
       - name: Set repo type
         uses: SkylineCommunications/_ReusableWorkflows/.github/actions/set-repo-type@WorkflowRepoType
         with:
           repo-types: Connector
-          token: ${{ env.REUSABLE_WORKFLOW_TOKEN }}
+          token: ${{ env.REUSABLE_WORKFLOWS_TOKEN }}

--- a/.github/workflows/Connector Master Workflow.yml
+++ b/.github/workflows/Connector Master Workflow.yml
@@ -112,6 +112,7 @@ jobs:
       tenant-id: ${{ steps.resolve.outputs.tenant-id }}
       subscription-id: ${{ steps.resolve.outputs.subscription-id }}
       use-oidc: ${{ steps.resolve.outputs.use-oidc }}
+      is-skyline-managed: ${{ steps.resolve.outputs.is-skyline-managed }}
     steps:
       - id: resolve
         uses: SkylineCommunications/_ReusableWorkflows/.github/actions/resolve-oidc@main
@@ -174,3 +175,40 @@ jobs:
       sonarCloudProjectName: ${{ inputs.sonarCloudProjectName }}
       debug: ${{ inputs.debug }}
     secrets: inherit
+
+  # Keep the enterprise custom property `Workflow-Repo-Type` in sync: a connector repo is always
+  # `Connector`. Runs only on the repository's default branch (feature branches / PRs / tags never
+  # flip the governance type) and only for Skyline-managed repos where OIDC (and thus the Key Vault
+  # token) is available. The write identity is the org-owner classic PAT `reusable-workflow-token`;
+  # the default GITHUB_TOKEN cannot write it.
+  set_repo_type:
+    name: Set Repo Type
+    needs: [check_oidc]
+    if: >-
+      github.ref_name == github.event.repository.default_branch &&
+      needs.check_oidc.outputs.is-skyline-managed == 'true' &&
+      needs.check_oidc.outputs.use-oidc == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Azure Login
+        uses: azure/login@v3
+        with:
+          client-id: ${{ needs.check_oidc.outputs.client-id }}
+          tenant-id: ${{ needs.check_oidc.outputs.tenant-id }}
+          subscription-id: ${{ needs.check_oidc.outputs.subscription-id }}
+
+      - name: Load secrets
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/load-secrets@main
+        with:
+          use-oidc: ${{ needs.check_oidc.outputs.use-oidc }}
+          secret-names: |
+            reusable-workflow-token
+
+      - name: Set repo type
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/set-repo-type@WorkflowRepoType
+        with:
+          repo-types: Connector
+          token: ${{ env.REUSABLE_WORKFLOW_TOKEN }}

--- a/.github/workflows/Connector Master Workflow.yml
+++ b/.github/workflows/Connector Master Workflow.yml
@@ -208,7 +208,7 @@ jobs:
             reusable-workflows-token
 
       - name: Set repo type
-        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/set-repo-type@WorkflowRepoType
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/set-repo-type@main
         with:
           repo-types: Connector
           token: ${{ env.REUSABLE_WORKFLOWS_TOKEN }}

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -234,7 +234,7 @@ jobs:
   # the conditional governance rulesets stay correct. Runs only on the repository's default branch
   # (feature branches / PRs / tags never flip the governance type) and only for Skyline-managed,
   # non-fork repos where OIDC (and thus the Key Vault token) is available. The write identity is the
-  # org-owner classic PAT `reusable-workflow-token`; the default GITHUB_TOKEN cannot write it.
+  # org-owner classic PAT `reusable-workflows-token`; the default GITHUB_TOKEN cannot write it.
   set_repo_type:
     name: Set Repo Type
     needs: [check_oidc, discover_projects]
@@ -260,7 +260,7 @@ jobs:
         with:
           use-oidc: ${{ needs.check_oidc.outputs.use-oidc }}
           secret-names: |
-            reusable-workflow-token
+            reusable-workflows-token
 
       - name: Compute repo types
         id: map
@@ -282,7 +282,7 @@ jobs:
         uses: SkylineCommunications/_ReusableWorkflows/.github/actions/set-repo-type@WorkflowRepoType
         with:
           repo-types: ${{ steps.map.outputs.repo-types }}
-          token: ${{ env.REUSABLE_WORKFLOW_TOKEN }}
+          token: ${{ env.REUSABLE_WORKFLOWS_TOKEN }}
 
   ci:
     name: CI

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -126,6 +126,7 @@ jobs:
     outputs:
       has-dataminer-projects: ${{ steps.detect-projects.outputs.has-dataminer-projects }}
       has-wix-projects: ${{ steps.detect-projects.outputs.has-wix-projects }}
+      has-nuget-projects: ${{ steps.detect-projects.outputs.has-nuget-projects }}
       has-ubuntu-dxm: ${{ inputs.dxm-projects-ubuntu != '' }}
       solution-path: ${{ steps.find-solution-file.outputs.path }}
     steps:
@@ -165,6 +166,7 @@ jobs:
           $solutionDir  = Split-Path $solutionPath -Parent
           $hasDataminerProjects = $false
           $hasWixProjects = $false
+          $hasNugetProjects = $false
 
           # Use dotnet sln list to enumerate projects in the solution (skip 2-line header)
           $projectPaths = dotnet sln "$solutionPath" list | Select-Object -Skip 2 | Where-Object { $_ -ne '' }
@@ -195,11 +197,21 @@ jobs:
               $hasWixProjects = $true
             }
 
-            if ($hasDataminerProjects -and $hasWixProjects) { break }
+            # Check for NuGet-publishing projects: those that opt into packaging
+            # (GeneratePackageOnBuild / IsPackable = true)
+            if (-not $hasNugetProjects) {
+              $generatePackage = $content.SelectNodes("//GeneratePackageOnBuild") | Where-Object { "$($_.InnerText)".Trim().ToLowerInvariant() -eq 'true' }
+              $isPackable = $content.SelectNodes("//IsPackable") | Where-Object { "$($_.InnerText)".Trim().ToLowerInvariant() -eq 'true' }
+              if ($generatePackage -or $isPackable) {
+                Write-Output "Found NuGet-publishing project: $relativePath"
+                $hasNugetProjects = $true
+              }
+            }
           }
 
           echo "has-dataminer-projects=$($hasDataminerProjects.ToString().ToLower())" >> $env:GITHUB_OUTPUT
           echo "has-wix-projects=$($hasWixProjects.ToString().ToLower())" >> $env:GITHUB_OUTPUT
+          echo "has-nuget-projects=$($hasNugetProjects.ToString().ToLower())" >> $env:GITHUB_OUTPUT
         shell: pwsh
 
   determine_version:
@@ -217,6 +229,60 @@ jobs:
           ref-type: ${{ github.ref_type }}
           ref-name: ${{ github.ref_name }}
           run-number: ${{ github.run_number }}
+
+  # Keep the enterprise custom property `Workflow-Repo-Type` in sync with what the repo builds, so
+  # the conditional governance rulesets stay correct. Runs only on the repository's default branch
+  # (feature branches / PRs / tags never flip the governance type) and only for Skyline-managed,
+  # non-fork repos where OIDC (and thus the Key Vault token) is available. The write identity is the
+  # org-owner classic PAT `reusable-workflow-token`; the default GITHUB_TOKEN cannot write it.
+  set_repo_type:
+    name: Set Repo Type
+    needs: [check_oidc, discover_projects]
+    if: >-
+      github.ref_name == github.event.repository.default_branch &&
+      needs.check_oidc.outputs.is-skyline-managed == 'true' &&
+      needs.check_oidc.outputs.is-fork != 'true' &&
+      needs.check_oidc.outputs.use-oidc == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Azure Login
+        uses: azure/login@v3
+        with:
+          client-id: ${{ needs.check_oidc.outputs.client-id }}
+          tenant-id: ${{ needs.check_oidc.outputs.tenant-id }}
+          subscription-id: ${{ needs.check_oidc.outputs.subscription-id }}
+
+      - name: Load secrets
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/load-secrets@main
+        with:
+          use-oidc: ${{ needs.check_oidc.outputs.use-oidc }}
+          secret-names: |
+            reusable-workflow-token
+
+      - name: Compute repo types
+        id: map
+        env:
+          HAS_DXM: ${{ needs.discover_projects.outputs.has-wix-projects == 'true' || needs.discover_projects.outputs.has-ubuntu-dxm == 'true' }}
+          HAS_APPPACKAGE: ${{ needs.discover_projects.outputs.has-dataminer-projects }}
+          HAS_NUGET: ${{ needs.discover_projects.outputs.has-nuget-projects }}
+        run: |
+          types=()
+          [[ "$HAS_DXM" == "true" ]] && types+=("DxM")
+          [[ "$HAS_APPPACKAGE" == "true" ]] && types+=("AppPackage")
+          [[ "$HAS_NUGET" == "true" ]] && types+=("NuGet")
+          IFS=','
+          echo "repo-types=${types[*]}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Set repo type
+        if: steps.map.outputs.repo-types != ''
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/set-repo-type@WorkflowRepoType
+        with:
+          repo-types: ${{ steps.map.outputs.repo-types }}
+          token: ${{ env.REUSABLE_WORKFLOW_TOKEN }}
 
   ci:
     name: CI

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -279,7 +279,7 @@ jobs:
 
       - name: Set repo type
         if: steps.map.outputs.repo-types != ''
-        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/set-repo-type@WorkflowRepoType
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/set-repo-type@main
         with:
           repo-types: ${{ steps.map.outputs.repo-types }}
           token: ${{ env.REUSABLE_WORKFLOWS_TOKEN }}

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -667,6 +667,17 @@ jobs:
           test "$BRANCH_VERSION" = "0.0.70000"
           test "$BRANCH_NUMERIC" = "0.0.4465.4465"
 
+  set-repo-type:
+    name: set-repo-type
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run repo-type mapping unit tests
+        shell: pwsh
+        run: ./.github/actions/set-repo-type/test.ps1
+
+
   package-debian:
     name: package-debian
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request introduces a new composite GitHub Action, `set-repo-type`, and integrates it into both the Connector and Master workflows. The action keeps the enterprise custom repository property `Workflow-Repo-Type` in sync with what the repository actually builds, ensuring governance rulesets remain accurate. The implementation includes robust input parsing, idempotency, and unit tests for core logic. The workflows are updated to detect repo types dynamically and call the action only in appropriate scenarios.

**New Action: Repository Type Management**

* Added the `set-repo-type` composite action, which writes the multi-select custom property `Workflow-Repo-Type` on the repository, ensuring the governance signal matches the repo's actual build outputs. The action is idempotent, normalizes input, and requires an org-owner token with the `repo` scope. [[1]](diffhunk://#diff-311fb98f29479347ede4660b3fea0d61981f3a936e707d7ee39733e191cfb2d3R1-R40)], [[2]](diffhunk://#diff-c5d63ce6d537879fcc93111d130f203b76ce900b7273661708cca93005009cd3R1-R65)], [[3]](diffhunk://#diff-3eaa2dd8926f1cc8f43e3b491af4c84db58bdbeed25e79334987348a74e49244R1-R130)])
* Added comprehensive unit tests for the action's helper functions to ensure correct parsing, comparison, and PATCH body generation without making API calls. ([[.github/actions/set-repo-type/test.ps1R1-R130](diffhunk://#diff-46f1e3773b247473a41e2fb18665b97bcb8f682c00ad7a9e26320485240e94a9R1-R130)])

**Workflow Integration**

* Updated the **Connector Master Workflow** to always set `Workflow-Repo-Type` to `Connector` on the default branch for Skyline-managed repos using OIDC, by invoking the new action. ([[.github/workflows/Connector Master Workflow.ymlR178-R214](diffhunk://#diff-0dace03534b5ffcaa75686dafb41e42bacd26eb889f471b2914408bce95e9cc9R178-R214)])
* Updated the **Master Workflow** to detect the presence of DxM, AppPackage, and NuGet projects, compute the appropriate set of repo types, and call the new action with the computed value on the default branch for Skyline-managed, non-fork repos. [[1]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R129)], [[2]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R169)], [[3]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3L198-R214)], [[4]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R233-R286)])

**Documentation**

* Updated the main action README to include `set-repo-type` and added a detailed README for the action itself, describing its purpose, inputs, behavior, permissions, and usage examples. [[1]](diffhunk://#diff-52d6b7f655d938f43fd7629a638b5183e3fcd1c3d302b3d32479aac06fdacb84R49)], [[2]](diffhunk://#diff-c5d63ce6d537879fcc93111d130f203b76ce900b7273661708cca93005009cd3R1-R65)])

**Other Workflow Improvements**

* Enhanced project discovery in the Master Workflow to detect NuGet-publishing projects by checking for `GeneratePackageOnBuild` or `IsPackable` properties in project files. [[1]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R169)], [[2]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3L198-R214)])

These changes ensure that repository governance properties are always accurate and automatically maintained, reducing manual intervention and potential drift.

**References:**  
[[1]](diffhunk://#diff-311fb98f29479347ede4660b3fea0d61981f3a936e707d7ee39733e191cfb2d3R1-R40) [[2]](diffhunk://#diff-c5d63ce6d537879fcc93111d130f203b76ce900b7273661708cca93005009cd3R1-R65) [[3]](diffhunk://#diff-3eaa2dd8926f1cc8f43e3b491af4c84db58bdbeed25e79334987348a74e49244R1-R130) [[4]](diffhunk://#diff-46f1e3773b247473a41e2fb18665b97bcb8f682c00ad7a9e26320485240e94a9R1-R130) [[5]](diffhunk://#diff-0dace03534b5ffcaa75686dafb41e42bacd26eb889f471b2914408bce95e9cc9R178-R214) [[6]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R129) [[7]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R169) [[8]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3L198-R214) [[9]](diffhunk://#diff-2e0e1f984826e62d696a296f3b39c6c54191c6ca503c1ee6d4e1b3b8c63df3d3R233-R286) [[10]](diffhunk://#diff-52d6b7f655d938f43fd7629a638b5183e3fcd1c3d302b3d32479aac06fdacb84R49)