### PR TITLE
Fix service name for Debian DxM packaging

### DIFF
--- a/.github/actions/package-debian/package-debian.sh
+++ b/.github/actions/package-debian/package-debian.sh
@@ -5,7 +5,7 @@
 #     (DEBIAN/{control,conffiles,preinst,postinst,prerm,postrm} + systemd unit);
 #   * each project is staged in its OWN temp tree so multiple .debs never share or
 #     clobber a single packaging/Debian/content;
-#   * the project folder name is the Debian service name.
+#   * the systemd unit filename (minus the .service extension) is the Debian service name.
 #
 # Env (set by action.yml):
 #   PROJECTS      : comma-separated project paths relative to the repo root.
@@ -57,7 +57,6 @@ for project in "${projects[@]}"; do
   project=$(printf '%s' "$project" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
   [[ -z "$project" ]] && continue
 
-  service_name=$(basename "$project")
   skeleton="$project/packaging/Debian"
 
   # 0. Validate: every listed project must ship the Debian skeleton.
@@ -65,6 +64,21 @@ for project in "${projects[@]}"; do
     echo "::error::Project '$project' is listed in dxm-projects-ubuntu but has no $skeleton/content/DEBIAN/control." >&2
     exit 1
   fi
+
+  # Derive the Debian service name from the systemd unit shipped in the skeleton
+  # (packaging/Debian/content/lib/systemd/system/<service>.service) rather than the
+  # project folder name.
+  systemd_dir="$skeleton/content/lib/systemd/system"
+  mapfile -t service_files < <(find "$systemd_dir" -maxdepth 1 -type f -name '*.service' 2>/dev/null | sort)
+  if [[ "${#service_files[@]}" -eq 0 ]]; then
+    echo "::error::Project '$project' has no *.service unit in $systemd_dir; cannot determine the Debian service name." >&2
+    exit 1
+  fi
+  if [[ "${#service_files[@]}" -gt 1 ]]; then
+    echo "::error::Project '$project' has multiple *.service units in $systemd_dir; expected exactly one." >&2
+    exit 1
+  fi
+  service_name=$(basename "${service_files[0]}" .service)
 
   echo "── Packaging '$service_name' ──"
   staging=$(mktemp -d)

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -695,14 +695,26 @@ jobs:
             sed -i 's#</Project>#  <ItemGroup><Content Include="appsettings.json" CopyToPublishDirectory="PreserveNewest" /></ItemGroup>\n</Project>#' "$svc/$svc.csproj"
             mkdir -p "$svc/packaging/Debian/content/DEBIAN"
             lower=$(echo "$svc" | tr '[:upper:]' '[:lower:]')
+            # Service name is derived from the systemd unit filename, NOT the project
+            # folder name, so give the unit a deliberately different name.
+            unit="dataminer-$lower"
+            mkdir -p "$svc/packaging/Debian/content/lib/systemd/system"
             {
-              echo "Package: $lower"
+              echo "[Unit]"
+              echo "Description=Test service $svc"
+              echo "[Service]"
+              echo "ExecStart=/opt/skyline-communications/$unit/$svc"
+              echo "[Install]"
+              echo "WantedBy=multi-user.target"
+            } > "$svc/packaging/Debian/content/lib/systemd/system/$unit.service"
+            {
+              echo "Package: $unit"
               echo "Version: <VERSION>"
               echo "Architecture: amd64"
               echo "Maintainer: Skyline Communications <devops@skyline.be>"
               echo "Description: Test service $svc"
             } > "$svc/packaging/Debian/content/DEBIAN/control"
-            echo "/etc/skyline-communications/$svc/appsettings.json" > "$svc/packaging/Debian/content/DEBIAN/conffiles"
+            echo "/etc/skyline-communications/$unit/appsettings.json" > "$svc/packaging/Debian/content/DEBIAN/conffiles"
           done
 
       - name: Invoke composite (pre-release version, no SBOM)
@@ -720,13 +732,13 @@ jobs:
         run: |
           ls -l deb-output
           test "$PACKAGE_COUNT" = "2"
-          test -f "deb-output/SvcOne_1.2.3~beta.1.deb"
-          test -f "deb-output/SvcTwo_1.2.3~beta.1.deb"
-          version=$(dpkg-deb --field "deb-output/SvcOne_1.2.3~beta.1.deb" Version)
+          test -f "deb-output/dataminer-svcone_1.2.3~beta.1.deb"
+          test -f "deb-output/dataminer-svctwo_1.2.3~beta.1.deb"
+          version=$(dpkg-deb --field "deb-output/dataminer-svcone_1.2.3~beta.1.deb" Version)
           test "$version" = "1.2.3~beta.1"
-          dpkg-deb --contents "deb-output/SvcOne_1.2.3~beta.1.deb" | grep -q 'opt/skyline-communications/SvcOne/'
-          dpkg-deb --contents "deb-output/SvcOne_1.2.3~beta.1.deb" | grep -q 'etc/skyline-communications/SvcOne/appsettings.json'
-          dpkg-deb --contents "deb-output/SvcTwo_1.2.3~beta.1.deb" | grep -q 'opt/skyline-communications/SvcTwo/'
+          dpkg-deb --contents "deb-output/dataminer-svcone_1.2.3~beta.1.deb" | grep -q 'opt/skyline-communications/dataminer-svcone/'
+          dpkg-deb --contents "deb-output/dataminer-svcone_1.2.3~beta.1.deb" | grep -q 'etc/skyline-communications/dataminer-svcone/appsettings.json'
+          dpkg-deb --contents "deb-output/dataminer-svctwo_1.2.3~beta.1.deb" | grep -q 'opt/skyline-communications/dataminer-svctwo/'
 
   remove-wix-projects:
     name: remove-wix-projects


### PR DESCRIPTION
This pull request updates the Debian packaging script to derive the service name from the systemd unit file rather than the project folder name. This ensures that the Debian service name matches the actual systemd unit being packaged, improving accuracy and reducing potential naming mismatches.

**Debian packaging improvements:**

* Changed the logic for determining the Debian service name to use the systemd unit filename (minus the `.service` extension) instead of the project folder name. (`.github/actions/package-debian/package-debian.sh`) [[1]](diffhunk://#diff-e7fb8da43a9d15215cbf4e18d07c0823cad9384662729c2614999bef5807f8c5L8-R8) [[2]](diffhunk://#diff-e7fb8da43a9d15215cbf4e18d07c0823cad9384662729c2614999bef5807f8c5L60) [[3]](diffhunk://#diff-e7fb8da43a9d15215cbf4e18d07c0823cad9384662729c2614999bef5807f8c5R68-R82)
* Added validation to ensure that each project has exactly one `.service` file in `packaging/Debian/content/lib/systemd/system`, with clear error messages if none or multiple are found. (`.github/actions/package-debian/package-debian.sh`)