### PR TITLE
Replace DxmRelease with DxMStorage

### DIFF
--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -1069,8 +1069,8 @@ jobs:
           skylinecommunicationscore-github-token: ${{ env.SKYLINECOMMUNICATIONSCORE_GITHUB_TOKEN }}
           azure-token: ${{ env.AZURE_TOKEN }}
 
-      - name: Install DxM release tool
-        run: dotnet tool install Skyline.DataMiner.CICD.Tools.DxmRelease --global --version 2.*
+      - name: Install DxM storage tool
+        run: dotnet tool install Skyline.DataMiner.CICD.Tools.DxMStorage --global
         shell: bash
 
       - name: Download signed installers
@@ -1082,13 +1082,14 @@ jobs:
       - name: Publish DxM installers
         env:
           RELEASE_ENVIRONMENT: ${{ matrix.environment }}
-          DEBUG_FLAG: ${{ inputs.debug }}
+          RELEASE_VERSION: ${{ github.ref_name }}
         run: |
-          dataminer-dxm-release \
-            --debug $DEBUG_FLAG \
+          dataminer-dxm-storage publish \
+            --credential-mode azure-cli \
+            --environment "$RELEASE_ENVIRONMENT" \
             --dxm-id-file dxm-id-file.json \
             --path-to-installers _SignedInstallers \
-            --environment "$RELEASE_ENVIRONMENT"
+            --version "$RELEASE_VERSION"
         shell: bash
 
   # ════════════════════════════════════════════════════════════════

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -1070,7 +1070,7 @@ jobs:
           azure-token: ${{ env.AZURE_TOKEN }}
 
       - name: Install DxM storage tool
-        run: dotnet tool install Skyline.DataMiner.CICD.Tools.DxMStorage --global --version '0.0.*'
+        run: dotnet tool install Skyline.DataMiner.CICD.Tools.DxMStorage --global --version '1.*'
         shell: bash
 
       - name: Download signed installers

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -1070,7 +1070,7 @@ jobs:
           azure-token: ${{ env.AZURE_TOKEN }}
 
       - name: Install DxM storage tool
-        run: dotnet tool install Skyline.DataMiner.CICD.Tools.DxMStorage --global
+        run: dotnet tool install Skyline.DataMiner.CICD.Tools.DxMStorage --global --version '0.0.*'
         shell: bash
 
       - name: Download signed installers
@@ -1083,8 +1083,10 @@ jobs:
         env:
           RELEASE_ENVIRONMENT: ${{ matrix.environment }}
           RELEASE_VERSION: ${{ github.ref_name }}
+          DEBUG_FLAG: ${{ inputs.debug }}
         run: |
           dataminer-dxm-storage publish \
+            --debug "$DEBUG_FLAG" \
             --credential-mode azure-cli \
             --environment "$RELEASE_ENVIRONMENT" \
             --dxm-id-file dxm-id-file.json \


### PR DESCRIPTION
## Summary

Replace the legacy `Skyline.DataMiner.CICD.Tools.DxmRelease` consumer in `upload_dxms` with `Skyline.DataMiner.CICD.Tools.DxMStorage`.

- installs the latest `0.0.*` DxMStorage tool from the Core NuGet registry
- forwards the Master Workflow `debug` input to `--debug`
- keeps Azure CLI/OIDC authentication
- passes the Git tag through `--version` as release metadata
- preserves the existing prerelease matrix (dev + qa) and stable matrix (dev + qa + prod)

## Version compatibility

The Orchestrator API currently requires `MAJOR.MINOR.PATCH.BUILD`. DxMStorage 0.0.3 therefore publishes the numeric MSI filename version (`A.B.C` becomes `A.B.C.0`; `A.B.C.D` is preserved). The Git tag is retained separately as Blob metadata for future backend SemVer support.

## Pilot verification

PilotDxM verified both paths against this branch:

- stable tag `0.6.0`: dev + qa + prod publication using backend version `0.6.0.0`
- prerelease tag `0.6.1-alpha`: dev + qa publication using backend version `0.6.1.120`
- debug output showed environment/auth selection, artifact upload, and successful API publication

## Validation

- `actionlint` clean
- DxMStorage: 51/51 .NET tests passed
- server synchronizer: 26/26 Pester tests passed
