### PR TITLE
Publish catalog item links after successful update

### DIFF
--- a/.github/workflows/Update Catalog Details Workflow.yml
+++ b/.github/workflows/Update Catalog Details Workflow.yml
@@ -264,9 +264,6 @@ jobs:
             foreach ($catalogFile in $catalogFiles) {
               $fullPath = "${{ github.workspace }}/$catalogFile"
 
-              # Use yq (a real YAML parser, preinstalled on GitHub-hosted runners) instead of
-              # regex/text-scraping. The "id"/"title" fields are the tool's documented, stable contract:
-              # https://docs.dataminer.services/user-guide/Cloud_Platform/Catalog/Register_Catalog_Item.html#manifest-file
               $catalogId = (yq eval '.id // ""' $fullPath) | Out-String | ForEach-Object { $_.Trim() }
               $title = (yq eval '.title // ""' $fullPath) | Out-String | ForEach-Object { $_.Trim() }
 
@@ -275,7 +272,6 @@ jobs:
                 continue
               }
 
-              # Derive the containing project folder name, shown alongside the title for context.
               $catalogDir = Split-Path $catalogFile -Parent
               if (-not [string]::IsNullOrWhiteSpace($catalogDir) -and (Split-Path $catalogDir -Leaf) -eq "CatalogInformation") {
                 $catalogDir = Split-Path $catalogDir -Parent
@@ -285,7 +281,6 @@ jobs:
               $displayName = if ([string]::IsNullOrWhiteSpace($title)) { $projectName } else { $title }
               $url = "https://catalog.dataminer.services/details/$catalogId"
 
-              Write-Host "Catalog item updated: $displayName ($projectName) -> $url"
               $links.Add("- [$displayName]($url) ``$projectName``")
             }
 

--- a/.github/workflows/Update Catalog Details Workflow.yml
+++ b/.github/workflows/Update Catalog Details Workflow.yml
@@ -25,6 +25,10 @@ on:
     secrets:
       api-key:
         required: false
+    outputs:
+      catalog-links:
+        description: Markdown links to updated DataMiner Catalog item(s).
+        value: ${{ jobs.update_catalog_details.outputs.catalog-links }}
 
 jobs:
 

--- a/.github/workflows/Update Catalog Details Workflow.yml
+++ b/.github/workflows/Update Catalog Details Workflow.yml
@@ -89,6 +89,8 @@ jobs:
       contents: write
       id-token: write
       actions: write
+    outputs:
+      catalog-links: ${{ steps.publish_catalog_links.outputs.catalog-links }}
     steps:
         - name: Azure Login
           uses: azure/login@v3
@@ -244,4 +246,50 @@ jobs:
                 --path-to-catalog-yml "${{ github.workspace }}/$catalogFile" `
                 --dm-catalog-token "${{ env.DATAMINER_TOKEN }}" `
                 --debug "${{ inputs.debug }}"
+            }
+
+        - name: Publish Catalog Links
+          id: publish_catalog_links
+          if: steps.detect_catalog_files.outputs.catalog-files != ''
+          shell: pwsh
+          run: |
+            $catalogFiles = @'
+            ${{ steps.detect_catalog_files.outputs.catalog-files }}
+            '@ -split "`r?`n" |
+              ForEach-Object { $_.Trim() } |
+              Where-Object { $_ -ne "" }
+
+            $links = New-Object System.Collections.Generic.List[string]
+
+            foreach ($catalogFile in $catalogFiles) {
+              $fullPath = "${{ github.workspace }}/$catalogFile"
+              $content = Get-Content -Path $fullPath -Raw
+
+              # Top-level (non-indented) "id:" and "title:" keys, with optional surrounding quotes.
+              $idMatch = [regex]::Match($content, '(?m)^id:\s*[''"]?([0-9a-fA-F-]{36})[''"]?\s*$')
+              $titleMatch = [regex]::Match($content, '(?m)^title:\s*[''"]?(.+?)[''"]?\s*$')
+
+              if (-not $idMatch.Success) {
+                Write-Host "::warning::Could not find a catalog ID in $catalogFile, skipping link generation."
+                continue
+              }
+
+              $catalogId = $idMatch.Groups[1].Value
+              $title = if ($titleMatch.Success) { $titleMatch.Groups[1].Value } else { $catalogId }
+              $url = "https://catalog.dataminer.services/details/$catalogId"
+
+              Write-Host "Catalog item updated: $title -> $url"
+              $links.Add("- [$title]($url)")
+            }
+
+            if ($links.Count -gt 0) {
+              "## :white_check_mark: Updated Catalog Item(s)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+              $links | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+
+              echo "catalog-links<<EOF" >> $env:GITHUB_OUTPUT
+              $links | ForEach-Object { echo $_ >> $env:GITHUB_OUTPUT }
+              echo "EOF" >> $env:GITHUB_OUTPUT
+            }
+            else {
+              Write-Host "::warning::No catalog IDs could be resolved; no links published."
             }

--- a/.github/workflows/Update Catalog Details Workflow.yml
+++ b/.github/workflows/Update Catalog Details Workflow.yml
@@ -265,26 +265,28 @@ jobs:
               $fullPath = "${{ github.workspace }}/$catalogFile"
 
               # Use yq (a real YAML parser, preinstalled on GitHub-hosted runners) instead of
-              # regex/text-scraping. The "id" field is the tool's documented, stable contract:
+              # regex/text-scraping. The "id"/"title" fields are the tool's documented, stable contract:
               # https://docs.dataminer.services/user-guide/Cloud_Platform/Catalog/Register_Catalog_Item.html#manifest-file
               $catalogId = (yq eval '.id // ""' $fullPath) | Out-String | ForEach-Object { $_.Trim() }
+              $title = (yq eval '.title // ""' $fullPath) | Out-String | ForEach-Object { $_.Trim() }
 
               if ([string]::IsNullOrWhiteSpace($catalogId)) {
                 Write-Host "::warning::Could not find a catalog ID in $catalogFile, skipping link generation."
                 continue
               }
 
-              # Use the catalog item's containing project folder name rather than its "title" field.
+              # Derive the containing project folder name, shown alongside the title for context.
               $catalogDir = Split-Path $catalogFile -Parent
               if (-not [string]::IsNullOrWhiteSpace($catalogDir) -and (Split-Path $catalogDir -Leaf) -eq "CatalogInformation") {
                 $catalogDir = Split-Path $catalogDir -Parent
               }
               $projectName = if ([string]::IsNullOrWhiteSpace($catalogDir)) { "${{ github.event.repository.name }}" } else { Split-Path $catalogDir -Leaf }
 
+              $displayName = if ([string]::IsNullOrWhiteSpace($title)) { $projectName } else { $title }
               $url = "https://catalog.dataminer.services/details/$catalogId"
 
-              Write-Host "Catalog item updated: $projectName -> $url"
-              $links.Add("- [$projectName]($url)")
+              Write-Host "Catalog item updated: $displayName ($projectName) -> $url"
+              $links.Add("- [$displayName]($url) ``$projectName``")
             }
 
             if ($links.Count -gt 0) {

--- a/.github/workflows/Update Catalog Details Workflow.yml
+++ b/.github/workflows/Update Catalog Details Workflow.yml
@@ -263,23 +263,28 @@ jobs:
 
             foreach ($catalogFile in $catalogFiles) {
               $fullPath = "${{ github.workspace }}/$catalogFile"
-              $content = Get-Content -Path $fullPath -Raw
 
-              # Top-level (non-indented) "id:" and "title:" keys, with optional surrounding quotes.
-              $idMatch = [regex]::Match($content, '(?m)^id:\s*[''"]?([0-9a-fA-F-]{36})[''"]?\s*$')
-              $titleMatch = [regex]::Match($content, '(?m)^title:\s*[''"]?(.+?)[''"]?\s*$')
+              # Use yq (a real YAML parser, preinstalled on GitHub-hosted runners) instead of
+              # regex/text-scraping. The "id" field is the tool's documented, stable contract:
+              # https://docs.dataminer.services/user-guide/Cloud_Platform/Catalog/Register_Catalog_Item.html#manifest-file
+              $catalogId = (yq eval '.id // ""' $fullPath) | Out-String | ForEach-Object { $_.Trim() }
 
-              if (-not $idMatch.Success) {
+              if ([string]::IsNullOrWhiteSpace($catalogId)) {
                 Write-Host "::warning::Could not find a catalog ID in $catalogFile, skipping link generation."
                 continue
               }
 
-              $catalogId = $idMatch.Groups[1].Value
-              $title = if ($titleMatch.Success) { $titleMatch.Groups[1].Value } else { $catalogId }
+              # Use the catalog item's containing project folder name rather than its "title" field.
+              $catalogDir = Split-Path $catalogFile -Parent
+              if (-not [string]::IsNullOrWhiteSpace($catalogDir) -and (Split-Path $catalogDir -Leaf) -eq "CatalogInformation") {
+                $catalogDir = Split-Path $catalogDir -Parent
+              }
+              $projectName = if ([string]::IsNullOrWhiteSpace($catalogDir)) { "${{ github.event.repository.name }}" } else { Split-Path $catalogDir -Leaf }
+
               $url = "https://catalog.dataminer.services/details/$catalogId"
 
-              Write-Host "Catalog item updated: $title -> $url"
-              $links.Add("- [$title]($url)")
+              Write-Host "Catalog item updated: $projectName -> $url"
+              $links.Add("- [$projectName]($url)")
             }
 
             if ($links.Count -gt 0) {

--- a/.github/workflows/Update Catalog Details Workflow.yml
+++ b/.github/workflows/Update Catalog Details Workflow.yml
@@ -92,7 +92,6 @@ jobs:
     permissions:
       contents: write
       id-token: write
-      actions: write
     outputs:
       catalog-links: ${{ steps.publish_catalog_links.outputs.catalog-links }}
     steps:

--- a/.github/workflows/Update Catalog Details Workflow.yml
+++ b/.github/workflows/Update Catalog Details Workflow.yml
@@ -281,7 +281,7 @@ jobs:
               $displayName = if ([string]::IsNullOrWhiteSpace($title)) { $projectName } else { $title }
               $url = "https://catalog.dataminer.services/details/$catalogId"
 
-              $links.Add("- [$displayName]($url) ``$projectName``")
+              $links.Add("- [$displayName | Catalog | dataminer.services]($url) ``Project[$projectName]``")
             }
 
             if ($links.Count -gt 0) {


### PR DESCRIPTION
Add functionality to generate and publish markdown links for updated catalog items in the job summary and outputs. Replace regex parsing with yq for improved reliability and display project names alongside catalog titles in the link format. Clean up redundant code and enhance the link output format.

Example here: https://github.com/SkylineCommunications/SLC-AS-GetViews/actions/runs/31101096932