### PR TITLE
Set InformationalVersion and improve DxM prerelease versions

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -45,7 +45,7 @@ Usage examples in each action README are sourced from the master workflows in
 | `update-global-json-sdks` | Rewrites managed `msbuild-sdks` versions in `global.json`. | [update-global-json-sdks/README.md](update-global-json-sdks/README.md) |
 | `apply-catalog-identifiers` | Rewrites manifest `id:` fields from mapping input. | [apply-catalog-identifiers/README.md](apply-catalog-identifiers/README.md) |
 | `compute-next-version` | Computes the next SemVer version from the latest final tag + Change-Type bump. | [compute-next-version/README.md](compute-next-version/README.md) |
-| `determine-version` | Determines the canonical build version (`version` + 4-field `numeric-version`) from the git ref. | [determine-version/README.md](determine-version/README.md) |
+| `determine-version` | Determines public, informational, assembly/file, and MSI versions from the git ref. | [determine-version/README.md](determine-version/README.md) |
 | `set-repo-type` | Writes the enterprise `Workflow-Repo-Type` custom property (idempotent read-before-write). | [set-repo-type/README.md](set-repo-type/README.md) |
 | `remove-wix-projects` | Strips WiX projects from a solution for cross-platform CI builds. | [remove-wix-projects/README.md](remove-wix-projects/README.md) |
 | `package-debian` | Builds a `.deb` per DxM project from per-project Debian skeletons. | [package-debian/README.md](package-debian/README.md) |

--- a/.github/actions/compute-next-version/README.md
+++ b/.github/actions/compute-next-version/README.md
@@ -13,13 +13,13 @@ bumping from the same final version.
 | --- | --- | --- |
 | `change-type` | no | The bump to apply: `Patch`, `Minor`, or `Major`. Empty resolves to `Patch`. |
 | `mode` | no | `release` (bare version) or `prerelease` (suffix appended). Defaults to `release`. |
-| `suffix` | no | Pre-release suffix body (e.g. `a1b2c3d4.42`). Used only when `mode` is `prerelease`. |
+| `suffix` | no | Pre-release suffix body (e.g. `123.42.a1b2c3d4`). Used only when `mode` is `prerelease`. |
 
 ## Outputs
 
 | Output | Description |
 | --- | --- |
-| `version` | The computed version, e.g. `1.4.0` or `1.4.0-a1b2c3d4.42`. |
+| `version` | The computed version, e.g. `1.4.0` or `1.4.0-123.42.a1b2c3d4`. |
 | `latest-tag` | The latest final tag the bump was computed from, or empty when none exists. |
 
 ## Rules
@@ -39,7 +39,7 @@ bumping from the same final version.
   with:
     change-type: ${{ steps.references.outputs.change-type }}
     mode: prerelease
-    suffix: a1b2c3d4.42
+    suffix: 123.42.a1b2c3d4
 ```
 
 The checkout that precedes this action must fetch tags (`fetch-depth: 0`) so the base tag can be

--- a/.github/actions/compute-next-version/action.yml
+++ b/.github/actions/compute-next-version/action.yml
@@ -15,13 +15,13 @@ inputs:
     required: false
     default: release
   suffix:
-    description: The pre-release suffix body (e.g. a1b2c3d4.42). Used only when mode is prerelease.
+    description: The pre-release suffix body (e.g. 123.42.a1b2c3d4). Used only when mode is prerelease.
     required: false
     default: ""
 
 outputs:
   version:
-    description: The computed version, e.g. 1.4.0 or 1.4.0-a1b2c3d4.42.
+    description: The computed version, e.g. 1.4.0 or 1.4.0-123.42.a1b2c3d4.
     value: ${{ steps.compute.outputs.version }}
   latest-tag:
     description: The latest final tag the bump was computed from, or empty when no final tag exists.

--- a/.github/actions/compute-next-version/test.ps1
+++ b/.github/actions/compute-next-version/test.ps1
@@ -82,7 +82,7 @@ try {
     Invoke-Case -Name 'Major bump on 1.3.5'              -Tags @('1.3.5')                -ChangeType 'Major' -Mode 'release'    -Suffix ''         -ExpectedVersion '2.0.0'            -ExpectedLatestTag '1.3.5'
     Invoke-Case -Name 'Patch bump, no tags'              -Tags @()                       -ChangeType 'Patch' -Mode 'release'    -Suffix ''         -ExpectedVersion '0.0.1'            -ExpectedLatestTag ''
     Invoke-Case -Name 'Minor bump ignores pre-release'   -Tags @('1.3.5', '1.4.0-dev.1') -ChangeType 'Minor' -Mode 'release'    -Suffix ''         -ExpectedVersion '1.4.0'            -ExpectedLatestTag '1.3.5'
-    Invoke-Case -Name 'Minor pre-release with suffix'    -Tags @('1.3.5')                -ChangeType 'Minor' -Mode 'prerelease' -Suffix 'a1b2c3d4.42' -ExpectedVersion '1.4.0-a1b2c3d4.42' -ExpectedLatestTag '1.3.5'
+    Invoke-Case -Name 'Minor pre-release with suffix'    -Tags @('1.3.5')                -ChangeType 'Minor' -Mode 'prerelease' -Suffix '123.42.a1b2c3d4' -ExpectedVersion '1.4.0-123.42.a1b2c3d4' -ExpectedLatestTag '1.3.5'
     Invoke-Case -Name 'Empty change-type defaults Patch' -Tags @('1.3.5')                -ChangeType ''      -Mode 'release'    -Suffix ''         -ExpectedVersion '1.3.6'            -ExpectedLatestTag '1.3.5'
 
     # Extra guards beyond the plan corpus.

--- a/.github/actions/determine-version/README.md
+++ b/.github/actions/determine-version/README.md
@@ -1,9 +1,10 @@
 # determine-version
 
-Determines the **single canonical build version** shared by every job in the Master Workflow, a
-strict 4-field numeric companion for assemblies, and an MSI-specific ProductVersion.
+Determines the **single canonical build version** shared by every job in the Master Workflow, an exact
+informational version, a strict 4-field numeric companion for assemblies, and an MSI-specific
+ProductVersion.
 
-- **Tag builds** use the tag name verbatim (e.g. `2.3.1`, `1.4.0-a1b2c3d4.42`).
+- **Tag builds** use the tag name verbatim (e.g. `2.3.1`, `1.4.0-123.42.a1b2c3d4`).
 - **Branch builds** keep the legacy `0.0.<run-number>` in all modes.
 
 ## Inputs
@@ -19,6 +20,7 @@ strict 4-field numeric companion for assemblies, and an MSI-specific ProductVers
 | Output | Suffix allowed? | Description |
 | --- | :--: | --- |
 | `version` | ✔ | Full SemVer — for MSBuild `Version` / `PackageVersion`, NuGet, `.dmapp` / Catalog, `.deb` (after its own `~` normalisation), DxM release. |
+| `informational-version` | ✔ | Exact `AssemblyInformationalVersion`, equal to `version`; builds disable automatic source-revision appending. |
 | `numeric-version` | ✘ | Strict 4-field `major.minor.patch.<build>` (every field wrapped `% 65535`) — for `AssemblyVersion` / `FileVersion`. `<build>` = the run number, or the version's own 4th field when it already has one. |
 | `product-version` | ✘ | Stable three-part tags use `major.minor.build`; prereleases, branches, and explicit four-part tags retain `numeric-version`'s fourth field for Skyline release classification. |
 | `product-version-valid` | — | `true` when MSI limits are met: major/minor ≤ 255 and build ≤ 65,535. |
@@ -39,9 +41,12 @@ strict 4-field numeric companion for assemblies, and an MSI-specific ProductVers
   fails the action with a clear error — such a version could not build anyway.
 - Stable three-part tags use the normalized three-field numeric core (`1.2.3`). Pre-release tags
   cannot carry their SemVer suffix in ProductVersion, so they use the suffix-free four-field
-  `numeric-version` (`1.2.3-sha.run` → `1.2.3.<workflow-run>`). Branch builds and explicit legacy
+  `numeric-version` (`1.2.3-pr.run.sha` → `1.2.3.<workflow-run>`). Branch builds and explicit legacy
   four-part tags also retain that fourth field. Skyline tooling uses this shape to distinguish a
   prerelease/non-final package from a stable release.
+- `informational-version` preserves the public version exactly, including a manual user suffix or the
+  automatic `PR.RUN.SHA` suffix. The Master Workflow passes
+  `IncludeSourceRevisionInInformationalVersion=false` so the SDK does not append another commit hash.
 - MSI limits are independent from assembly limits: **major ≤ 255, minor ≤ 255, build ≤ 65,535**.
   `product-version-valid` exposes the result. The Master Workflow fails clearly on an invalid value
   only when a WiX project exists, so a non-MSI repository may still use a date-style tag such as

--- a/.github/actions/determine-version/action.yml
+++ b/.github/actions/determine-version/action.yml
@@ -22,8 +22,11 @@ inputs:
 
 outputs:
   version:
-    description: The full SemVer version — the tag name on tag builds (e.g. `2.3.1`, `1.4.0-a1b2c3d4.42`), `0.0.<run-number>` on branch builds.
+    description: The full SemVer version — the tag name on tag builds (e.g. `2.3.1`, `1.4.0-123.42.a1b2c3d4`), `0.0.<run-number>` on branch builds.
     value: ${{ steps.determine.outputs.version }}
+  informational-version:
+    description: The exact assembly informational version, equal to `version` without an automatically appended source revision.
+    value: ${{ steps.determine.outputs.informational-version }}
   numeric-version:
     description: Strict 4-field `major.minor.patch.<build>` version with any pre-release/build suffix stripped; `<build>` is the run number, or the version's own 4th field when it already has one; every field is wrapped into the valid assembly-metadata range (`% 65535`, max 65534).
     value: ${{ steps.determine.outputs.numeric-version }}

--- a/.github/actions/determine-version/determine-version.ps1
+++ b/.github/actions/determine-version/determine-version.ps1
@@ -24,6 +24,7 @@ if ($refType -eq 'tag') {
 } else {
     $version = "0.0.$runNumber"
 }
+$informationalVersion = $version
 
 # numeric-version: strip any pre-release/build suffix (-… / +…) down to the numeric core,
 # then ensure 4 fields. A 3-field core (major.minor.patch — SemVer tags) gets the run
@@ -71,10 +72,11 @@ $productVersionValid = if ($refType -eq 'tag') {
     $true
 }
 
-Write-Host "Determined version '$version', numeric-version '$numericVersion', and product-version '$productVersion' (valid: $($productVersionValid.ToString().ToLowerInvariant()), ref-type: $refType, run-number: $runNumber)."
+Write-Host "Determined version '$version', informational-version '$informationalVersion', numeric-version '$numericVersion', and product-version '$productVersion' (valid: $($productVersionValid.ToString().ToLowerInvariant()), ref-type: $refType, run-number: $runNumber)."
 
 @(
     "version=$version"
+    "informational-version=$informationalVersion"
     "numeric-version=$numericVersion"
     "product-version=$productVersion"
     "product-version-valid=$($productVersionValid.ToString().ToLowerInvariant())"

--- a/.github/actions/determine-version/test.ps1
+++ b/.github/actions/determine-version/test.ps1
@@ -43,6 +43,7 @@ function Invoke-Case {
         [Parameter(Mandatory)][string]$ExpectedVersion,
         [Parameter(Mandatory)][string]$ExpectedNumericVersion,
         [Parameter(Mandatory)][string]$ExpectedProductVersion,
+        [AllowEmptyString()][string]$ExpectedInformationalVersion = '',
         [bool]$ExpectedProductVersionValid = $true
     )
 
@@ -58,11 +59,14 @@ function Invoke-Case {
         & $script:scriptPath | Out-Null
 
         $version = Get-OutputValue -Name 'version' -Path $outputFile
+        $informationalVersion = Get-OutputValue -Name 'informational-version' -Path $outputFile
         $numericVersion = Get-OutputValue -Name 'numeric-version' -Path $outputFile
         $productVersion = Get-OutputValue -Name 'product-version' -Path $outputFile
         $productVersionValid = Get-OutputValue -Name 'product-version-valid' -Path $outputFile
 
         Assert-Equal -Actual $version -Expected $ExpectedVersion -Label "${Name} (version)"
+        $expectedInformational = if ([string]::IsNullOrEmpty($ExpectedInformationalVersion)) { $ExpectedVersion } else { $ExpectedInformationalVersion }
+        Assert-Equal -Actual $informationalVersion -Expected $expectedInformational -Label "${Name} (informational-version)"
         Assert-Equal -Actual $numericVersion -Expected $ExpectedNumericVersion -Label "${Name} (numeric-version)"
         Assert-Equal -Actual $productVersion -Expected $ExpectedProductVersion -Label "${Name} (product-version)"
         Assert-Equal -Actual $productVersionValid -Expected $ExpectedProductVersionValid.ToString().ToLowerInvariant() -Label "${Name} (product-version-valid)"
@@ -112,9 +116,10 @@ try {
     Invoke-Case -Name 'Branch build'                       -RefType 'branch' -RefName 'dev/my-feature'            -RunNumber '42'    -ExpectedVersion '0.0.42'                 -ExpectedNumericVersion '0.0.42.42'     -ExpectedProductVersion '0.0.42.42'
     Invoke-Case -Name 'Branch build, large run number'     -RefType 'branch' -RefName 'main'                      -RunNumber '70000' -ExpectedVersion '0.0.70000'              -ExpectedNumericVersion '0.0.4465.4465' -ExpectedProductVersion '0.0.4465.4465'
 
-    # Tag builds use the tag name; numeric-version strips the suffix + appends the run number.
+    # Tag builds use the tag name for Version and InformationalVersion; numeric-version strips the suffix + appends the run number.
     Invoke-Case -Name 'Final release tag'                  -RefType 'tag'    -RefName '1.2.3'                     -RunNumber '7'     -ExpectedVersion '1.2.3'                  -ExpectedNumericVersion '1.2.3.7'      -ExpectedProductVersion '1.2.3'
-    Invoke-Case -Name 'Pre-release tag'                    -RefType 'tag'    -RefName '1.4.0-a1b2c3d4.42'         -RunNumber '99'    -ExpectedVersion '1.4.0-a1b2c3d4.42'      -ExpectedNumericVersion '1.4.0.99'      -ExpectedProductVersion '1.4.0.99'
+    Invoke-Case -Name 'Manual pre-release tag'             -RefType 'tag'    -RefName '1.4.0-userSuffix'          -RunNumber '98'    -ExpectedVersion '1.4.0-userSuffix'       -ExpectedNumericVersion '1.4.0.98'     -ExpectedProductVersion '1.4.0.98'
+    Invoke-Case -Name 'Pre-release tag'                    -RefType 'tag'    -RefName '1.4.0-123.42.a1b2c3d4'     -RunNumber '99'    -ExpectedVersion '1.4.0-123.42.a1b2c3d4'  -ExpectedNumericVersion '1.4.0.99'      -ExpectedProductVersion '1.4.0.99'
     Invoke-Case -Name 'Build-metadata tag'                 -RefType 'tag'    -RefName '2.3.1+build.5'             -RunNumber '3'     -ExpectedVersion '2.3.1+build.5'          -ExpectedNumericVersion '2.3.1.3'      -ExpectedProductVersion '2.3.1'
     Invoke-Case -Name 'Pre-release + metadata tag'         -RefType 'tag'    -RefName '1.2.3-rc.1+meta'           -RunNumber '8'     -ExpectedVersion '1.2.3-rc.1+meta'        -ExpectedNumericVersion '1.2.3.8'       -ExpectedProductVersion '1.2.3.8'
     Invoke-Case -Name 'Leading v prefix tolerated'         -RefType 'tag'    -RefName 'v1.2.3'                    -RunNumber '5'     -ExpectedVersion 'v1.2.3'                 -ExpectedNumericVersion '1.2.3.5'      -ExpectedProductVersion '1.2.3'

--- a/.github/actions/package-debian/README.md
+++ b/.github/actions/package-debian/README.md
@@ -22,6 +22,8 @@ from the publish output → substitute `<VERSION>` in `DEBIAN/control` → fix p
 | --- | --- | --- |
 | `projects` | yes | Comma-separated DxM project paths (relative to the repo root). |
 | `version` | yes | Canonical build version (from `determine-version`). Debian-normalised here: `x.y.z-suffix` → `x.y.z~suffix` (dashes in the suffix removed, dots preserved). |
+| `informational-version` | no | Exact assembly informational version. Defaults to `version`. Automatic source-revision appending is disabled. |
+| `numeric-version` | no | Strict four-field value used for `AssemblyVersion` and `FileVersion`. |
 | `generate-sbom` | no | `'true'` ⇒ generate an SBOM per project (requires the `dataminer-sbom` tool on the PATH; full releases only). Default `'false'`. |
 | `configuration` | no | `dotnet publish` configuration. Default `Release`. |
 | `output-directory` | no | Directory receiving the `.deb` files. Default `output`. |
@@ -40,6 +42,8 @@ from the publish output → substitute `<VERSION>` in `DEBIAN/control` → fix p
   with:
     projects: ${{ inputs.dxm-projects-ubuntu }}
     version: ${{ needs.determine_version.outputs.version }}
+    informational-version: ${{ needs.determine_version.outputs.informational-version }}
+    numeric-version: ${{ needs.determine_version.outputs.numeric-version }}
     generate-sbom: ${{ !contains(github.ref_name, '-') }}
 ```
 
@@ -48,5 +52,6 @@ from the publish output → substitute `<VERSION>` in `DEBIAN/control` → fix p
 Covered by the `package-debian` job in
 [`../../workflows/Test composite actions.yml`](../../workflows/Test%20composite%20actions.yml),
 which scaffolds two console projects with Debian skeletons and asserts the built `.deb`s
-(name, `~`-normalised version, publish output and conffile contents). `dpkg-deb` requires a
+(name, `~`-normalised version, publish output, conffile contents, and managed assembly versions).
+`dpkg-deb` requires a
 Linux runner, so there is no local `test.ps1`.

--- a/.github/actions/package-debian/action.yml
+++ b/.github/actions/package-debian/action.yml
@@ -13,6 +13,14 @@ inputs:
   version:
     description: The canonical build version (from `determine-version`). Normalised for Debian (`x.y.z-suffix` → `x.y.z~suffix`).
     required: true
+  informational-version:
+    description: Exact assembly informational version. Defaults to `version` when empty.
+    required: false
+    default: ''
+  numeric-version:
+    description: Optional strict four-field AssemblyVersion and FileVersion.
+    required: false
+    default: ''
   generate-sbom:
     description: When `true`, generate an SBOM into `usr/share/doc/skyline-communications-<project>` (requires the `dataminer-sbom` tool; full releases only).
     required: false
@@ -40,6 +48,8 @@ runs:
       env:
         PROJECTS: ${{ inputs.projects }}
         VERSION: ${{ inputs.version }}
+        INFORMATIONAL_VERSION: ${{ inputs.informational-version }}
+        NUMERIC_VERSION: ${{ inputs.numeric-version }}
         GENERATE_SBOM: ${{ inputs.generate-sbom }}
         CONFIGURATION: ${{ inputs.configuration }}
         OUTPUT_DIR: ${{ inputs.output-directory }}

--- a/.github/actions/package-debian/package-debian.sh
+++ b/.github/actions/package-debian/package-debian.sh
@@ -10,6 +10,8 @@
 # Env (set by action.yml):
 #   PROJECTS      : comma-separated project paths relative to the repo root.
 #   VERSION       : canonical build version (Debian-normalised here: x.y.z-suffix -> x.y.z~suffix).
+#   INFORMATIONAL_VERSION : exact assembly informational version; defaults to VERSION.
+#   NUMERIC_VERSION       : optional strict 4-field AssemblyVersion/FileVersion.
 #   GENERATE_SBOM : 'true' => generate SBOM into usr/share/doc/skyline-communications-<name>.
 #   CONFIGURATION : dotnet publish configuration.
 #   OUTPUT_DIR    : directory receiving the built .deb files.
@@ -28,6 +30,7 @@ if [[ -z "${VERSION:-}" ]]; then
 fi
 configuration="${CONFIGURATION:-Release}"
 output_dir="${OUTPUT_DIR:-output}"
+informational_version="${INFORMATIONAL_VERSION:-$VERSION}"
 
 # --- Debian version normalisation -------------------------------------------------
 # Pre-release x.y.z-suffix -> x.y.z~suffix (dashes inside the suffix removed; '~' sorts
@@ -89,7 +92,24 @@ for project in "${projects[@]}"; do
 
   # 2. Publish self-contained for linux-x64 into opt/skyline-communications/<name>.
   publish_dir="$content/opt/skyline-communications/$service_name"
-  dotnet publish "$project" -c "$configuration" -r linux-x64 --self-contained true -o "$publish_dir"
+  publish_args=(
+    "$project"
+    -c "$configuration"
+    -r linux-x64
+    --self-contained true
+    -o "$publish_dir"
+    -p:Version="$VERSION"
+    -p:PackageVersion="$VERSION"
+    -p:InformationalVersion="$informational_version"
+    -p:IncludeSourceRevisionInInformationalVersion=false
+  )
+  if [[ -n "${NUMERIC_VERSION:-}" ]]; then
+    publish_args+=(
+      -p:AssemblyVersion="$NUMERIC_VERSION"
+      -p:FileVersion="$NUMERIC_VERSION"
+    )
+  fi
+  dotnet publish "${publish_args[@]}"
 
   # 3. SBOM (full releases only): usr/share/doc/skyline-communications-<name>,
   #    matching the Azure reusable pipelines.

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -220,6 +220,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.determine-version.outputs.version }}
+      informational-version: ${{ steps.determine-version.outputs.informational-version }}
       numeric-version: ${{ steps.determine-version.outputs.numeric-version }}
       product-version: ${{ steps.determine-version.outputs.product-version }}
       product-version-valid: ${{ steps.determine-version.outputs.product-version-valid }}
@@ -524,6 +525,8 @@ jobs:
         env:
           SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
           VERSION: ${{ needs.determine_version.outputs.version }}
+          INFORMATIONAL_VERSION: ${{ needs.determine_version.outputs.informational-version }}
+          NUMERIC_VERSION: ${{ needs.determine_version.outputs.numeric-version }}
           CONFIGURATION: ${{ inputs.configuration }}
           DEBUG_FLAG: ${{ inputs.debug }}
         run: |
@@ -534,6 +537,10 @@ jobs:
           dotnet build "$SOLUTION_PATH" \
             -p:Version="$VERSION" \
             -p:PackageVersion="$VERSION" \
+            -p:AssemblyVersion="$NUMERIC_VERSION" \
+            -p:FileVersion="$NUMERIC_VERSION" \
+            -p:InformationalVersion="$INFORMATIONAL_VERSION" \
+            -p:IncludeSourceRevisionInInformationalVersion=false \
             --configuration "$CONFIGURATION" \
             -p:SkylineDataMinerSdkDebug="$DEBUG_FLAG" \
             -p:GeneratePackageOnBuild=false \
@@ -636,6 +643,8 @@ jobs:
         with:
           projects: ${{ inputs.dxm-projects-ubuntu }}
           version: ${{ needs.determine_version.outputs.version }}
+          informational-version: ${{ needs.determine_version.outputs.informational-version }}
+          numeric-version: ${{ needs.determine_version.outputs.numeric-version }}
           generate-sbom: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
           configuration: ${{ inputs.configuration }}
           output-directory: output
@@ -768,14 +777,15 @@ jobs:
           OVERRIDE_CATALOG_DOWNLOAD_TOKEN: ${{ secrets.OVERRIDE_CATALOG_DOWNLOAD_TOKEN }}
           SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
           VERSION: ${{ needs.determine_version.outputs.version }}
+          INFORMATIONAL_VERSION: ${{ needs.determine_version.outputs.informational-version }}
           NUMERIC_VERSION: ${{ needs.determine_version.outputs.numeric-version }}
           PRODUCT_VERSION: ${{ needs.determine_version.outputs.product-version }}
           CONFIGURATION: ${{ inputs.configuration }}
           DEBUG_FLAG: ${{ inputs.debug }}
         run: |
-          # NuGet/DataMiner packaging uses the full (suffix-bearing) version; assemblies and
-          # assemblies use the strict 4-field numeric version. WiX uses the dedicated
-          # ProductVersion (three fields for stable SemVer tags).
+          # NuGet/DataMiner packaging uses the full (suffix-bearing) version; managed
+          # assemblies use the exact informational version and strict 4-field numeric
+          # versions. WiX uses the dedicated ProductVersion (three fields for stable tags).
           # DefineConstants comes from the job-level env var so the WiX projects can keep
           # their own preprocessor constants (a -p: global would clobber them).
           dotnet build "$SOLUTION_PATH" \
@@ -783,6 +793,8 @@ jobs:
             -p:PackageVersion="$VERSION" \
             -p:AssemblyVersion="$NUMERIC_VERSION" \
             -p:FileVersion="$NUMERIC_VERSION" \
+            -p:InformationalVersion="$INFORMATIONAL_VERSION" \
+            -p:IncludeSourceRevisionInInformationalVersion=false \
             -p:ProductVersion="$PRODUCT_VERSION" \
             --configuration "$CONFIGURATION" \
             -p:CatalogPublishKeyName="DATAMINER_TOKEN" \
@@ -839,6 +851,7 @@ jobs:
         env:
           SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
           VERSION: ${{ needs.determine_version.outputs.version }}
+          INFORMATIONAL_VERSION: ${{ needs.determine_version.outputs.informational-version }}
           NUMERIC_VERSION: ${{ needs.determine_version.outputs.numeric-version }}
           PRODUCT_VERSION: ${{ needs.determine_version.outputs.product-version }}
           CONFIGURATION: ${{ inputs.configuration }}
@@ -853,6 +866,8 @@ jobs:
             -p:PackageVersion="$env:VERSION" `
             -p:AssemblyVersion="$env:NUMERIC_VERSION" `
             -p:FileVersion="$env:NUMERIC_VERSION" `
+            -p:InformationalVersion="$env:INFORMATIONAL_VERSION" `
+            -p:IncludeSourceRevisionInInformationalVersion=false `
             -p:ProductVersion="$env:PRODUCT_VERSION" `
             -p:GeneratePackageOnBuild=false `
             -p:GenerateDataMinerPackage=false `

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -635,7 +635,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Run 23-case version corpus
+      - name: Run 24-case version corpus
         shell: pwsh
         run: ./.github/actions/determine-version/test.ps1
 
@@ -644,7 +644,7 @@ jobs:
         uses: ./.github/actions/determine-version
         with:
           ref-type: tag
-          ref-name: 1.4.0-a1b2c3d4.42
+          ref-name: 1.4.0-123.42.a1b2c3d4
           run-number: 99
 
       - name: Stable tag build smoke test
@@ -666,22 +666,28 @@ jobs:
       - name: Assert composite outputs
         env:
           TAG_VERSION: ${{ steps.tag-build.outputs.version }}
+          TAG_INFORMATIONAL: ${{ steps.tag-build.outputs.informational-version }}
           TAG_NUMERIC: ${{ steps.tag-build.outputs.numeric-version }}
           TAG_PRODUCT: ${{ steps.tag-build.outputs.product-version }}
           TAG_PRODUCT_VALID: ${{ steps.tag-build.outputs.product-version-valid }}
           STABLE_NUMERIC: ${{ steps.stable-tag-build.outputs.numeric-version }}
+          STABLE_INFORMATIONAL: ${{ steps.stable-tag-build.outputs.informational-version }}
           STABLE_PRODUCT: ${{ steps.stable-tag-build.outputs.product-version }}
           BRANCH_VERSION: ${{ steps.branch-build.outputs.version }}
+          BRANCH_INFORMATIONAL: ${{ steps.branch-build.outputs.informational-version }}
           BRANCH_NUMERIC: ${{ steps.branch-build.outputs.numeric-version }}
           BRANCH_PRODUCT: ${{ steps.branch-build.outputs.product-version }}
         run: |
-          test "$TAG_VERSION" = "1.4.0-a1b2c3d4.42"
+          test "$TAG_VERSION" = "1.4.0-123.42.a1b2c3d4"
+          test "$TAG_INFORMATIONAL" = "1.4.0-123.42.a1b2c3d4"
           test "$TAG_NUMERIC" = "1.4.0.99"
           test "$TAG_PRODUCT" = "1.4.0.99"
           test "$TAG_PRODUCT_VALID" = "true"
           test "$STABLE_NUMERIC" = "1.4.0.100"
+          test "$STABLE_INFORMATIONAL" = "1.4.0"
           test "$STABLE_PRODUCT" = "1.4.0"
           test "$BRANCH_VERSION" = "0.0.70000"
+          test "$BRANCH_INFORMATIONAL" = "0.0.70000"
           test "$BRANCH_NUMERIC" = "0.0.4465.4465"
           test "$BRANCH_PRODUCT" = "0.0.4465.4465"
 
@@ -741,6 +747,8 @@ jobs:
         with:
           projects: ${{ runner.temp }}/deb-demo/SvcOne, ${{ runner.temp }}/deb-demo/SvcTwo
           version: 1.2.3-beta.1
+          informational-version: 1.2.3-beta.1
+          numeric-version: 1.2.3.77
           generate-sbom: 'false'
           output-directory: deb-output
 
@@ -757,6 +765,27 @@ jobs:
           dpkg-deb --contents "deb-output/dataminer-svcone_1.2.3~beta.1.deb" | grep -q 'opt/skyline-communications/dataminer-svcone/'
           dpkg-deb --contents "deb-output/dataminer-svcone_1.2.3~beta.1.deb" | grep -q 'etc/skyline-communications/dataminer-svcone/appsettings.json'
           dpkg-deb --contents "deb-output/dataminer-svctwo_1.2.3~beta.1.deb" | grep -q 'opt/skyline-communications/dataminer-svctwo/'
+
+      - name: Assert managed assembly versions in Debian package
+        shell: pwsh
+        run: |
+          $extractPath = Join-Path $env:RUNNER_TEMP 'deb-extract'
+          & dpkg-deb --extract 'deb-output/dataminer-svcone_1.2.3~beta.1.deb' $extractPath
+          if ($LASTEXITCODE -ne 0) { throw "dpkg-deb extraction failed with exit code $LASTEXITCODE." }
+
+          $assemblyPath = Join-Path $extractPath 'opt/skyline-communications/dataminer-svcone/SvcOne.dll'
+          $assemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($assemblyPath)
+          if ($assemblyName.Version.ToString() -ne '1.2.3.77') {
+            throw "Unexpected AssemblyVersion: $($assemblyName.Version)."
+          }
+
+          $fileInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($assemblyPath)
+          if ($fileInfo.FileVersion -ne '1.2.3.77') {
+            throw "Unexpected FileVersion: $($fileInfo.FileVersion)."
+          }
+          if ($fileInfo.ProductVersion -ne '1.2.3-beta.1') {
+            throw "Unexpected InformationalVersion: $($fileInfo.ProductVersion)."
+          }
 
   remove-wix-projects:
     name: remove-wix-projects


### PR DESCRIPTION
## Summary

Improve DxM version traceability and make managed assembly metadata explicit across CI and packaging.

- change automatically generated prerelease tags from `A.B.C-SHA.RUN` to `A.B.C-PR.RUN.SHA`
- expose `informational-version` from `determine-version`
- set `InformationalVersion` exactly and disable the .NET SDK source-revision suffix
- apply the existing numeric version consistently to `AssemblyVersion` and `FileVersion`
- propagate the version contract through regular CI, Windows packaging, WiX rebuilds, and Linux publishing
- extend action and Linux package tests to verify generated version values and compiled assembly metadata

## Version contract

Definitions:

- `A.B.C`: selected semantic version
- `P`: pull request number
- `T`: auto-tag workflow run number
- `R`: workflow run number building the ref
- `S`: eight-character commit SHA
- `U`: user-provided valid SemVer prerelease suffix

| Build type | Public/package version | InformationalVersion | AssemblyVersion / FileVersion | MSI ProductVersion | Debian version |
|---|---|---|---|---|---|
| Full release | `A.B.C` | `A.B.C` | `A.B.C.R` | `A.B.C` | `A.B.C` |
| Manual prerelease | `A.B.C-U` | `A.B.C-U` | `A.B.C.R` | `A.B.C.R` | `A.B.C~U` |
| Automatic prerelease | `A.B.C-P.T.S` | `A.B.C-P.T.S` | `A.B.C.R` | `A.B.C.R` | `A.B.C~P.T.S` |
| Regular build | `0.0.R` | `0.0.R` | `0.0.R.R` | `0.0.R.R` | `0.0.R` |

For automatic prereleases, `T` belongs to the auto-tag workflow that creates the tag. `R` belongs to the separate tag-triggered workflow that builds it.

## Implementation details

- `auto-tag.yml` validates the PR number, run number, and short SHA before producing `PR.RUN.SHA`.
- `determine-version` keeps the public version as the exact informational version.
- managed builds pass `IncludeSourceRevisionInInformationalVersion=false` to avoid an extra SDK-appended commit hash.
- regular CI and Linux publishing now receive the same numeric assembly/file version contract as Windows packaging.
- the Debian composite accepts explicit informational and numeric versions and passes them to `dotnet publish`.

## Validation

- `compute-next-version`: 11 offline cases passed
- `determine-version`: 24 offline cases passed, including manual and automatic prereleases
- `actionlint`: clean for changed workflows
- Bash syntax and ShellCheck: clean for the normalized Debian script
- compiled assembly probe verified exact informational, assembly, and file versions
- Linux CI test extracts a generated `.deb` and verifies the managed assembly metadata
- `git diff --check`: clean