### PR TITLE
Reorder the Package & Sign (Windows) job

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -48,6 +48,7 @@ Usage examples in each action README are sourced from the master workflows in
 | `determine-version` | Determines public, informational, assembly/file, and MSI versions from the git ref. | [determine-version/README.md](determine-version/README.md) |
 | `set-repo-type` | Writes the enterprise `Workflow-Repo-Type` custom property (idempotent read-before-write). | [set-repo-type/README.md](set-repo-type/README.md) |
 | `remove-wix-projects` | Strips WiX projects from a solution for cross-platform CI builds. | [remove-wix-projects/README.md](remove-wix-projects/README.md) |
+| `partition-solution-projects` | Splits a solution into remaining, WiX, and DataMiner package build stages. | [partition-solution-projects/README.md](partition-solution-projects/README.md) |
 | `package-debian` | Builds a `.deb` per DxM project from per-project Debian skeletons. | [package-debian/README.md](package-debian/README.md) |
 | `apply-source-code-url` | Fills empty `source_code_url:` fields in catalog manifests. | [apply-source-code-url/README.md](apply-source-code-url/README.md) |
 | `sonarcloud-status` | Checks SonarCloud project status and emits analysis flag. | [sonarcloud-status/README.md](sonarcloud-status/README.md) |

--- a/.github/actions/partition-solution-projects/README.md
+++ b/.github/actions/partition-solution-projects/README.md
@@ -1,0 +1,66 @@
+# partition-solution-projects
+
+Copies one `.sln`, `.slnx`, or `.slnf` file into three uniquely named sibling solutions so later jobs can process project categories independently. The source solution or filter and project files are never modified.
+
+## Classification contract
+
+- `wix`: projects whose file extension is `.wixproj`.
+- `dataminer-package`: non-WiX projects whose XML explicitly contains a `GenerateDataMinerPackage` element with trimmed text equal to `true`, case-insensitively.
+- `remaining`: every other project, including WiX custom-action `.csproj` projects, `DataMinerType` projects without an explicit true package flag, false values, expressions, missing elements, and values supplied only through imports.
+
+The action fails closed when the source solution or a referenced project is missing, when a non-WiX project contains malformed XML, or when `dotnet sln list/remove` fails. Each output solution starts as a source copy, preserving solution configurations, folders, and project mappings for the projects it retains.
+
+## Inputs
+
+| Input | Required | Description |
+| --- | --- | --- |
+| `solution-path` | yes | Path to the source `.sln`, `.slnx`, or `.slnf` file. |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `remaining-solution-path` | Absolute path to the copied solution containing remaining projects. |
+| `remaining-count` | Number of projects in the remaining partition. |
+| `wix-solution-path` | Absolute path to the copied solution containing WiX projects. |
+| `wix-count` | Number of projects in the WiX partition. |
+| `dataminer-package-solution-path` | Absolute path to the copied solution containing DataMiner package projects. |
+| `dataminer-package-count` | Number of projects in the DataMiner package partition. |
+
+## Permissions
+
+The action requires no elevated GitHub token permissions. A caller that checks out repository content can use:
+
+```yaml
+permissions:
+  contents: read
+```
+
+## Usage
+
+Run this after checkout and .NET SDK setup:
+
+```yaml
+- name: Partition solution projects
+  id: partition
+  uses: SkylineCommunications/_ReusableWorkflows/.github/actions/partition-solution-projects@main
+  with:
+    solution-path: src/Example.sln
+
+- name: Build remaining projects
+  if: steps.partition.outputs.remaining-count != '0'
+  shell: pwsh
+  env:
+    SOLUTION_PATH: ${{ steps.partition.outputs.remaining-solution-path }}
+  run: dotnet build $env:SOLUTION_PATH --configuration Release
+```
+
+Repeated invocations are safe: every invocation creates new GUID-qualified sibling solution names. Empty categories still produce usable zero-project solution files and report a count of `0`.
+
+## Tests
+
+The offline test scaffolds supported solution formats with the installed `dotnet` SDK and does not restore or build any project:
+
+```pwsh
+pwsh -NoProfile -File ./test.ps1
+```

--- a/.github/actions/partition-solution-projects/action.yml
+++ b/.github/actions/partition-solution-projects/action.yml
@@ -1,0 +1,40 @@
+name: Partition solution projects
+description: >
+  Copies a solution into remaining, WiX, and DataMiner package partitions
+  without modifying the source solution.
+
+inputs:
+  solution-path:
+    description: Path to the source solution file (`.sln`, `.slnx`, or `.slnf`) to partition.
+    required: true
+
+outputs:
+  remaining-solution-path:
+    description: Path to the copied solution containing all unclassified projects.
+    value: ${{ steps.partition.outputs.remaining-solution-path }}
+  remaining-count:
+    description: Number of projects in the remaining solution partition.
+    value: ${{ steps.partition.outputs.remaining-count }}
+  wix-solution-path:
+    description: Path to the copied solution containing only WiX projects.
+    value: ${{ steps.partition.outputs.wix-solution-path }}
+  wix-count:
+    description: Number of projects in the WiX solution partition.
+    value: ${{ steps.partition.outputs.wix-count }}
+  dataminer-package-solution-path:
+    description: Path to the copied solution containing only DataMiner package projects.
+    value: ${{ steps.partition.outputs.dataminer-package-solution-path }}
+  dataminer-package-count:
+    description: Number of projects in the DataMiner package solution partition.
+    value: ${{ steps.partition.outputs.dataminer-package-count }}
+
+runs:
+  using: composite
+  steps:
+    - name: Partition solution projects
+      id: partition
+      shell: pwsh
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        SOLUTION_PATH: ${{ inputs.solution-path }}
+      run: '& (Join-Path $env:ACTION_PATH "partition-solution-projects.ps1")'

--- a/.github/actions/partition-solution-projects/partition-solution-projects.ps1
+++ b/.github/actions/partition-solution-projects/partition-solution-projects.ps1
@@ -1,0 +1,183 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-DotNet {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments
+    )
+
+    $commandOutput = @(& dotnet @Arguments 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        $details = ($commandOutput | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine
+        throw "dotnet $($Arguments -join ' ') failed with exit code $LASTEXITCODE.$([Environment]::NewLine)$details"
+    }
+
+    return $commandOutput
+}
+
+function Get-SolutionProject {
+    param(
+        [Parameter(Mandatory)]
+        [string]$SolutionPath
+    )
+
+    $solutionDirectory = Split-Path -Parent $SolutionPath
+    $listOutput = @(Invoke-DotNet -Arguments @('sln', $SolutionPath, 'list'))
+    $separatorIndex = -1
+
+    for ($lineIndex = 0; $lineIndex -lt $listOutput.Count; $lineIndex++) {
+        if ($listOutput[$lineIndex].ToString().Trim() -match '^-{3,}$') {
+            $separatorIndex = $lineIndex
+            break
+        }
+    }
+
+    if ($separatorIndex -lt 0) {
+        if ($listOutput | Where-Object { $_.ToString() -match '(?i)no projects found' }) {
+            return @()
+        }
+
+        throw "Could not parse the project list for solution '$SolutionPath'."
+    }
+
+    $projects = @()
+    foreach ($projectLine in $listOutput[($separatorIndex + 1)..($listOutput.Count - 1)]) {
+        $listedPath = $projectLine.ToString().Trim()
+        if ([string]::IsNullOrWhiteSpace($listedPath)) {
+            continue
+        }
+
+        $platformPath = $listedPath.Replace('\', [System.IO.Path]::DirectorySeparatorChar).Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+        $projectPath = if ([System.IO.Path]::IsPathFullyQualified($platformPath)) {
+            [System.IO.Path]::GetFullPath($platformPath)
+        } else {
+            [System.IO.Path]::GetFullPath((Join-Path -Path $solutionDirectory -ChildPath $platformPath))
+        }
+
+        if (-not (Test-Path -LiteralPath $projectPath -PathType Leaf)) {
+            throw "Project '$listedPath' referenced by solution '$SolutionPath' does not exist."
+        }
+
+        $projects += [PSCustomObject]@{
+            ListedPath = $listedPath
+            FullPath   = $projectPath
+            Category   = $null
+        }
+    }
+
+    return $projects
+}
+
+function Get-ProjectCategory {
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectPath
+    )
+
+    if ([System.IO.Path]::GetExtension($ProjectPath).Equals('.wixproj', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return 'wix'
+    }
+
+    try {
+        $xmlDocument = [System.Xml.XmlDocument]::new()
+        $xmlDocument.XmlResolver = $null
+        $xmlDocument.Load($ProjectPath)
+    } catch {
+        throw "Project '$ProjectPath' contains malformed XML: $($_.Exception.Message)"
+    }
+
+    $packageElements = $xmlDocument.SelectNodes("//*[local-name()='GenerateDataMinerPackage']")
+    foreach ($packageElement in $packageElements) {
+        if ($packageElement.InnerText.Trim().Equals('true', [System.StringComparison]::OrdinalIgnoreCase)) {
+            return 'dataminer-package'
+        }
+    }
+
+    return 'remaining'
+}
+
+function Remove-PartitionProject {
+    param(
+        [Parameter(Mandatory)]
+        [string]$SolutionPath,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [string[]]$ProjectPath
+    )
+
+    if ($ProjectPath.Count -eq 0) {
+        return
+    }
+
+    $arguments = @('sln', $SolutionPath, 'remove') + $ProjectPath
+    Invoke-DotNet -Arguments $arguments | Out-Null
+}
+
+if ([string]::IsNullOrWhiteSpace($env:SOLUTION_PATH)) {
+    throw 'SOLUTION_PATH must be set.'
+}
+
+if ([string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT)) {
+    throw 'GITHUB_OUTPUT must be set.'
+}
+
+if ($null -eq (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+    throw 'dotnet must be installed and available on PATH.'
+}
+
+$sourceSolutionPath = [System.IO.Path]::GetFullPath($env:SOLUTION_PATH)
+if (-not (Test-Path -LiteralPath $sourceSolutionPath -PathType Leaf)) {
+    throw "Solution '$sourceSolutionPath' does not exist."
+}
+
+$solutionExtension = [System.IO.Path]::GetExtension($sourceSolutionPath)
+if ($solutionExtension -notin '.sln', '.slnx', '.slnf') {
+    throw "Solution '$sourceSolutionPath' must have a .sln, .slnx, or .slnf extension."
+}
+
+$projects = @(Get-SolutionProject -SolutionPath $sourceSolutionPath)
+foreach ($project in $projects) {
+    $project.Category = Get-ProjectCategory -ProjectPath $project.FullPath
+}
+
+$solutionDirectory = Split-Path -Parent $sourceSolutionPath
+$solutionName = [System.IO.Path]::GetFileNameWithoutExtension($sourceSolutionPath)
+$invocationId = [System.Guid]::NewGuid().ToString('N')
+$partitionNames = @('remaining', 'wix', 'dataminer-package')
+$partitionPaths = @{}
+
+try {
+    foreach ($partitionName in $partitionNames) {
+        $partitionFileName = "$solutionName.$partitionName.$invocationId$solutionExtension"
+        $partitionPath = Join-Path -Path $solutionDirectory -ChildPath $partitionFileName
+        Copy-Item -LiteralPath $sourceSolutionPath -Destination $partitionPath
+        $partitionPaths[$partitionName] = $partitionPath
+
+        $projectsToRemove = @($projects | Where-Object { $_.Category -ne $partitionName } | ForEach-Object { $_.FullPath })
+        Remove-PartitionProject -SolutionPath $partitionPath -ProjectPath $projectsToRemove
+    }
+
+    $outputLines = @(
+        "remaining-solution-path=$($partitionPaths['remaining'])"
+        "remaining-count=$(@($projects | Where-Object { $_.Category -eq 'remaining' }).Count)"
+        "wix-solution-path=$($partitionPaths['wix'])"
+        "wix-count=$(@($projects | Where-Object { $_.Category -eq 'wix' }).Count)"
+        "dataminer-package-solution-path=$($partitionPaths['dataminer-package'])"
+        "dataminer-package-count=$(@($projects | Where-Object { $_.Category -eq 'dataminer-package' }).Count)"
+    )
+    $outputWriter = [System.IO.StreamWriter]::new($env:GITHUB_OUTPUT, $true, [System.Text.UTF8Encoding]::new($false))
+    try {
+        foreach ($outputLine in $outputLines) {
+            $outputWriter.WriteLine($outputLine)
+        }
+    } finally {
+        $outputWriter.Dispose()
+    }
+} catch {
+    foreach ($partitionPath in $partitionPaths.Values) {
+        Remove-Item -LiteralPath $partitionPath -Force -ErrorAction SilentlyContinue
+    }
+
+    throw
+}

--- a/.github/actions/partition-solution-projects/test.ps1
+++ b/.github/actions/partition-solution-projects/test.ps1
@@ -1,0 +1,352 @@
+$ErrorActionPreference = 'Stop'
+
+$actionDirectory = Split-Path -Parent $PSCommandPath
+$scriptPath = Join-Path -Path $actionDirectory -ChildPath 'partition-solution-projects.ps1'
+$temporaryDirectory = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "partition-solution-projects-$([System.Guid]::NewGuid())"
+New-Item -Path $temporaryDirectory -ItemType Directory | Out-Null
+
+function Invoke-DotNet {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments,
+
+        [switch]$AllowFailure
+    )
+
+    $commandOutput = @(& dotnet @Arguments 2>&1)
+    if ($LASTEXITCODE -ne 0 -and -not $AllowFailure.IsPresent) {
+        throw "dotnet $($Arguments -join ' ') failed: $($commandOutput -join [Environment]::NewLine)"
+    }
+
+    return [PSCustomObject]@{
+        ExitCode = $LASTEXITCODE
+        Output   = $commandOutput
+    }
+}
+
+function Assert-Equal {
+    param(
+        [AllowNull()]
+        [object]$Actual,
+
+        [AllowNull()]
+        [object]$Expected,
+
+        [Parameter(Mandatory)]
+        [string]$Label
+    )
+
+    if ($Actual -ne $Expected) {
+        throw "${Label}: expected '${Expected}', got '${Actual}'."
+    }
+}
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory)]
+        [bool]$Condition,
+
+        [Parameter(Mandatory)]
+        [string]$Label
+    )
+
+    if (-not $Condition) {
+        throw "${Label}: expected true."
+    }
+}
+
+function Get-OutputValue {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $prefix = "${Name}="
+    $line = Get-Content -LiteralPath $Path | Where-Object { $_.StartsWith($prefix, [System.StringComparison]::Ordinal) } | Select-Object -Last 1
+    if ($null -eq $line) {
+        throw "Output '$Name' was not written."
+    }
+
+    return $line.Substring($prefix.Length)
+}
+
+function Set-ProjectFile {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [string]$Content
+    )
+
+    $projectDirectory = Split-Path -Parent $Path
+    New-Item -Path $projectDirectory -ItemType Directory -Force | Out-Null
+    Set-Content -LiteralPath $Path -Value $Content -Encoding utf8
+}
+
+function New-TestSolution {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('sln', 'slnx', 'slnf')]
+        [string]$Format
+    )
+
+    $solutionDirectory = Join-Path -Path $script:temporaryDirectory -ChildPath "$Name-$Format"
+    New-Item -Path $solutionDirectory -ItemType Directory | Out-Null
+    $solutionFormat = if ($Format -eq 'slnf') { 'sln' } else { $Format }
+    $creationResult = Invoke-DotNet -Arguments @('new', 'sln', '--name', $Name, '--output', $solutionDirectory, '--format', $solutionFormat) -AllowFailure
+    if ($creationResult.ExitCode -ne 0) {
+        Remove-Item -LiteralPath $solutionDirectory -Recurse -Force
+        return $null
+    }
+
+    if ($Format -eq 'slnf') {
+        $solutionPath = Join-Path -Path $solutionDirectory -ChildPath "$Name.slnf"
+        $filter = [ordered]@{
+            solution = [ordered]@{
+                path     = "$Name.sln"
+                projects = @()
+            }
+        }
+        $filter | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath $solutionPath -Encoding utf8
+    } else {
+        $solutionPath = Join-Path -Path $solutionDirectory -ChildPath "$Name.$Format"
+    }
+
+    if (-not (Test-Path -LiteralPath $solutionPath -PathType Leaf)) {
+        throw "dotnet created no .$Format solution at '$solutionPath'."
+    }
+
+    return $solutionPath
+}
+
+function Add-Project {
+    param(
+        [Parameter(Mandatory)]
+        [string]$SolutionPath,
+
+        [Parameter(Mandatory)]
+        [string]$RelativePath,
+
+        [Parameter(Mandatory)]
+        [string]$Content
+    )
+
+    $solutionDirectory = Split-Path -Parent $SolutionPath
+    $projectPath = Join-Path -Path $solutionDirectory -ChildPath $RelativePath
+    Set-ProjectFile -Path $projectPath -Content $Content
+
+    if ([System.IO.Path]::GetExtension($SolutionPath) -eq '.slnf') {
+        $filter = Get-Content -LiteralPath $SolutionPath -Raw | ConvertFrom-Json
+        $backingSolutionPath = Join-Path -Path $solutionDirectory -ChildPath $filter.solution.path
+        Invoke-DotNet -Arguments @('sln', $backingSolutionPath, 'add', $projectPath) | Out-Null
+        $filterProjectPath = [System.IO.Path]::GetRelativePath($solutionDirectory, $projectPath).Replace('/', '\')
+        $filter.solution.projects = @($filter.solution.projects) + $filterProjectPath
+        $filter | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath $SolutionPath -Encoding utf8
+    } else {
+        Invoke-DotNet -Arguments @('sln', $SolutionPath, 'add', $projectPath) | Out-Null
+    }
+
+    return $projectPath
+}
+
+function Get-SolutionProjectName {
+    param(
+        [Parameter(Mandatory)]
+        [string]$SolutionPath
+    )
+
+    $listResult = Invoke-DotNet -Arguments @('sln', $SolutionPath, 'list')
+    $lines = @($listResult.Output | ForEach-Object { $_.ToString().Trim() })
+    $separatorIndex = -1
+    for ($lineIndex = 0; $lineIndex -lt $lines.Count; $lineIndex++) {
+        if ($lines[$lineIndex] -match '^-{3,}$') {
+            $separatorIndex = $lineIndex
+            break
+        }
+    }
+
+    if ($separatorIndex -lt 0) {
+        return @()
+    }
+
+    return @($lines[($separatorIndex + 1)..($lines.Count - 1)] |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        ForEach-Object { $_.Replace('\', '/') } |
+        Sort-Object)
+}
+
+function Invoke-Partition {
+    param(
+        [Parameter(Mandatory)]
+        [string]$SolutionPath
+    )
+
+    $outputPath = Join-Path -Path $script:temporaryDirectory -ChildPath "$([System.Guid]::NewGuid()).output"
+    New-Item -Path $outputPath -ItemType File | Out-Null
+    $env:SOLUTION_PATH = $SolutionPath
+    $env:GITHUB_OUTPUT = $outputPath
+    try {
+        & $script:scriptPath | Out-Null
+    } finally {
+        Remove-Item Env:\SOLUTION_PATH -ErrorAction SilentlyContinue
+        Remove-Item Env:\GITHUB_OUTPUT -ErrorAction SilentlyContinue
+    }
+
+    return $outputPath
+}
+
+function Assert-Partition {
+    param(
+        [Parameter(Mandatory)]
+        [string]$OutputPath,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('remaining', 'wix', 'dataminer-package')]
+        [string]$Partition,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [string[]]$ExpectedProject,
+
+        [Parameter(Mandatory)]
+        [int]$ExpectedCount
+    )
+
+    $solutionPath = Get-OutputValue -Name "$Partition-solution-path" -Path $OutputPath
+    $count = Get-OutputValue -Name "$Partition-count" -Path $OutputPath
+    Assert-True -Condition ([System.IO.Path]::IsPathFullyQualified($solutionPath)) -Label "$Partition path is absolute"
+    Assert-True -Condition (Test-Path -LiteralPath $solutionPath -PathType Leaf) -Label "$Partition solution exists"
+    Assert-Equal -Actual $count -Expected $ExpectedCount.ToString() -Label "$Partition count"
+
+    $actualProjects = @(Get-SolutionProjectName -SolutionPath $solutionPath)
+    $expectedProjects = @($ExpectedProject | Sort-Object)
+    Assert-Equal -Actual ($actualProjects -join '|') -Expected ($expectedProjects -join '|') -Label "$Partition projects"
+}
+
+function Assert-PartitionFailure {
+    param(
+        [Parameter(Mandatory)]
+        [string]$SolutionPath,
+
+        [Parameter(Mandatory)]
+        [string]$ExpectedMessage,
+
+        [Parameter(Mandatory)]
+        [string]$Label
+    )
+
+    try {
+        Invoke-Partition -SolutionPath $SolutionPath | Out-Null
+        throw "${Label}: expected the partition script to fail."
+    } catch {
+        if (-not $_.Exception.Message.Contains($ExpectedMessage, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "${Label}: unexpected error '$($_.Exception.Message)'."
+        }
+    }
+}
+
+$plainProject = '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>'
+$wixProject = '<Project Sdk="WixToolset.Sdk/6.0.0"></Project>'
+$packageTrueProject = '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><GenerateDataMinerPackage>  TrUe  </GenerateDataMinerPackage></PropertyGroup></Project>'
+$packageFalseProject = '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><GenerateDataMinerPackage>false</GenerateDataMinerPackage></PropertyGroup></Project>'
+$dataMinerTypeProject = '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><DataMinerType>Automation</DataMinerType></PropertyGroup></Project>'
+$expressionProject = '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><GenerateDataMinerPackage>$(PackageEnabled)</GenerateDataMinerPackage></PropertyGroup></Project>'
+$customActionProject = '<Project Sdk="Microsoft.NET.Sdk"><ItemGroup><PackageReference Include="WixToolset.Dtf.CustomAction" Version="6.0.0" /></ItemGroup></Project>'
+
+try {
+    if ($null -eq (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+        throw 'dotnet must be installed and available on PATH.'
+    }
+
+    $testedFormats = @()
+    foreach ($format in @('sln', 'slnx', 'slnf')) {
+        $sourceSolutionPath = New-TestSolution -Name 'PartitionTest' -Format $format
+        if ($null -eq $sourceSolutionPath) {
+            Write-Host "SKIP: .$format is not supported by the installed dotnet SDK."
+            continue
+        }
+
+        $testedFormats += $format
+        Add-Project -SolutionPath $sourceSolutionPath -RelativePath 'Plain/Plain.csproj' -Content $plainProject | Out-Null
+        Add-Project -SolutionPath $sourceSolutionPath -RelativePath 'Installer/Installer.wixproj' -Content $wixProject | Out-Null
+        Add-Project -SolutionPath $sourceSolutionPath -RelativePath 'PackageTrue/PackageTrue.csproj' -Content $packageTrueProject | Out-Null
+        Add-Project -SolutionPath $sourceSolutionPath -RelativePath 'PackageFalse/PackageFalse.csproj' -Content $packageFalseProject | Out-Null
+        Add-Project -SolutionPath $sourceSolutionPath -RelativePath 'DataMinerType/DataMinerType.csproj' -Content $dataMinerTypeProject | Out-Null
+        Add-Project -SolutionPath $sourceSolutionPath -RelativePath 'Expression/Expression.csproj' -Content $expressionProject | Out-Null
+        Add-Project -SolutionPath $sourceSolutionPath -RelativePath 'CustomAction/CustomAction.csproj' -Content $customActionProject | Out-Null
+
+        $sourceHash = (Get-FileHash -LiteralPath $sourceSolutionPath -Algorithm SHA256).Hash
+        $backingSolutionPath = if ($format -eq 'slnf') {
+            Join-Path -Path (Split-Path -Parent $sourceSolutionPath) -ChildPath 'PartitionTest.sln'
+        } else {
+            $null
+        }
+        $backingSolutionHash = if ($null -ne $backingSolutionPath) {
+            (Get-FileHash -LiteralPath $backingSolutionPath -Algorithm SHA256).Hash
+        } else {
+            $null
+        }
+
+        $firstOutput = Invoke-Partition -SolutionPath $sourceSolutionPath
+        Assert-Equal -Actual (Get-FileHash -LiteralPath $sourceSolutionPath -Algorithm SHA256).Hash -Expected $sourceHash -Label ".$format source unchanged"
+        if ($null -ne $backingSolutionPath) {
+            Assert-Equal -Actual (Get-FileHash -LiteralPath $backingSolutionPath -Algorithm SHA256).Hash -Expected $backingSolutionHash -Label ".$format backing solution unchanged"
+        }
+
+        Assert-Partition -OutputPath $firstOutput -Partition remaining -ExpectedProject @(
+            'CustomAction/CustomAction.csproj',
+            'DataMinerType/DataMinerType.csproj',
+            'Expression/Expression.csproj',
+            'PackageFalse/PackageFalse.csproj',
+            'Plain/Plain.csproj'
+        ) -ExpectedCount 5
+        Assert-Partition -OutputPath $firstOutput -Partition wix -ExpectedProject @('Installer/Installer.wixproj') -ExpectedCount 1
+        Assert-Partition -OutputPath $firstOutput -Partition dataminer-package -ExpectedProject @('PackageTrue/PackageTrue.csproj') -ExpectedCount 1
+
+        $secondOutput = Invoke-Partition -SolutionPath $sourceSolutionPath
+        foreach ($partition in @('remaining', 'wix', 'dataminer-package')) {
+            $firstPath = Get-OutputValue -Name "$partition-solution-path" -Path $firstOutput
+            $secondPath = Get-OutputValue -Name "$partition-solution-path" -Path $secondOutput
+            Assert-True -Condition ($firstPath -ne $secondPath) -Label ".$format repeated $partition path is unique"
+            Assert-True -Condition (Test-Path -LiteralPath $secondPath -PathType Leaf) -Label ".$format repeated $partition solution exists"
+        }
+
+        Write-Host "PASS: .$format exact partitions, source preservation, and unique repeat invocation"
+    }
+
+    Assert-True -Condition ($testedFormats.Count -gt 0) -Label 'At least one solution format is supported'
+
+    $zeroSolutionPath = New-TestSolution -Name 'ZeroPartitions' -Format $testedFormats[0]
+    Add-Project -SolutionPath $zeroSolutionPath -RelativePath 'Plain/Plain.csproj' -Content $plainProject | Out-Null
+    $zeroOutput = Invoke-Partition -SolutionPath $zeroSolutionPath
+    Assert-Partition -OutputPath $zeroOutput -Partition remaining -ExpectedProject @('Plain/Plain.csproj') -ExpectedCount 1
+    Assert-Partition -OutputPath $zeroOutput -Partition wix -ExpectedProject @() -ExpectedCount 0
+    Assert-Partition -OutputPath $zeroOutput -Partition dataminer-package -ExpectedProject @() -ExpectedCount 0
+    Write-Host 'PASS: zero-count partitions'
+
+    $missingSolutionPath = New-TestSolution -Name 'MissingProject' -Format $testedFormats[0]
+    $missingProjectPath = Add-Project -SolutionPath $missingSolutionPath -RelativePath 'Missing/Missing.csproj' -Content $plainProject
+    Remove-Item -LiteralPath $missingProjectPath -Force
+    Assert-PartitionFailure -SolutionPath $missingSolutionPath -ExpectedMessage 'does not exist' -Label 'Missing project'
+    Write-Host 'PASS: missing project fails closed'
+
+    $malformedSolutionPath = New-TestSolution -Name 'MalformedProject' -Format $testedFormats[0]
+    $malformedProjectPath = Add-Project -SolutionPath $malformedSolutionPath -RelativePath 'Malformed/Malformed.csproj' -Content $plainProject
+    Set-Content -LiteralPath $malformedProjectPath -Value '<Project><PropertyGroup></Project>' -Encoding utf8
+    Assert-PartitionFailure -SolutionPath $malformedSolutionPath -ExpectedMessage 'malformed XML' -Label 'Malformed project XML'
+    Write-Host 'PASS: malformed project XML fails closed'
+
+    Assert-PartitionFailure -SolutionPath (Join-Path -Path $temporaryDirectory -ChildPath 'missing.sln') -ExpectedMessage 'does not exist' -Label 'Missing solution'
+    Write-Host 'PASS: missing solution fails closed'
+
+    Write-Host "All partition-solution-projects tests passed for: $($testedFormats -join ', ')."
+} finally {
+    Remove-Item -LiteralPath $temporaryDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/.github/instructions/reusable-workflows.instructions.md
+++ b/.github/instructions/reusable-workflows.instructions.md
@@ -20,6 +20,30 @@ This file applies when editing workflows under `.github/workflows/` or composite
 - **Secrets travel via `env:`, never `with:`.** Never log secrets.
 - **Job-scoped `permissions:`** — start from the least set the job needs (`contents: read` minimum) and add only what is required.
 
+### Catalog workflow compatibility
+
+When editing [`Update Catalog Details Workflow.yml`](../workflows/Update%20Catalog%20Details%20Workflow.yml):
+
+- Keep DataMiner project detection exactly aligned with [`Master Workflow.yml`](../workflows/Master%20Workflow.yml): scan every `*.csproj`, parse it as XML, and treat the repository as a DataMiner SDK scenario when any project contains a `DataMinerType` element. Do not introduce a different SDK-detection heuristic without updating Master Workflow as well.
+- In the DataMiner SDK scenario, process each package manifest under a `CatalogInformation` directory. SDK package manifests are guaranteed to use this location.
+- In the legacy connector/automation scenario, preserve the existing root `catalog.yml` / `manifest.yml` behavior.
+- Catalog generation through `github-to-catalog-yaml` and the commit/push of `.githubtocatalog/auto-generated-catalog.yml` are legacy-only operations. Skip all of them for the DataMiner SDK scenario.
+- Before changing permissions, inspect the permissions required by each actual step and action. Do not add scopes such as `actions: write` based only on artifact upload or other assumptions; keep the smallest verified set and use job-level permissions.
+
+### Workflow validation checklist
+
+After editing a reusable workflow:
+
+1. Run the editor diagnostics or an available YAML/workflow validator and fix structural errors before reviewing warnings.
+2. Check that every job-level mapping (`name`, `runs-on`, `needs`, `permissions`, `steps`) is aligned consistently.
+3. Verify both relevant branches when conditional behavior is changed: legacy connector/automation and DataMiner SDK multi-package repositories.
+4. Confirm that skipped steps cannot be referenced as though they produced outputs in the active branch.
+5. Review the final diff for unrelated changes and confirm permissions remain least-privilege.
+
+### Documentation sync
+
+For important changes to reusable workflows or their behavior, check whether the corresponding documentation in `C:\GitHub\dataminer-docs\develop\CICD\GitHub\GitHubReusableWorkflows` also needs to be updated. Before finishing, ask the user whether they will make the documentation changes themselves or want guidance through making them. Do not require documentation changes for minor, internal, or non-user-visible workflow updates.
+
 ## Referencing composite actions from inside this repo
 
 ```yaml

--- a/.github/instructions/reusable-workflows.instructions.md
+++ b/.github/instructions/reusable-workflows.instructions.md
@@ -40,6 +40,18 @@ After editing a reusable workflow:
 4. Confirm that skipped steps cannot be referenced as though they produced outputs in the active branch.
 5. Review the final diff for unrelated changes and confirm permissions remain least-privilege.
 
+### Script and tool validation
+
+- PowerShell comparison operators applied to arrays return the matching or non-matching elements, not one Boolean result. Join command output before using `-match` or `-notmatch`, or use an explicit predicate such as `Where-Object`.
+- Some command-line tools return a failure code when a glob matches no files. Before invoking a tool for an optional artifact type, explicitly check whether matching files exist. Do not suppress failures from an invocation that had actual inputs.
+- A composite action's smoke test must exercise the same invocation path used by its workflow caller, including the composite interface, outputs, and command-output parsing. An offline script test alone does not validate the workflow wrapper.
+
+### Partitioned build ordering
+
+- When a later build stage consumes signed outputs from an earlier stage, pass `BuildProjectReferences=false` to the later build. Otherwise MSBuild can rebuild a dependency and replace its signed output.
+- Treat artifact staging directories as explicit contracts between build stages. Verify that required artifacts exist before starting the consuming stage.
+- Preserve every solution format accepted by the caller when introducing solution manipulation. `solution-filter-name` can resolve to `.sln`, `.slnx`, or `.slnf`; tests for `.slnf` must also verify that its backing solution remains unchanged.
+
 ### Documentation sync
 
 For important changes to reusable workflows or their behavior, check whether the corresponding documentation in `C:\GitHub\dataminer-docs\develop\CICD\GitHub\GitHubReusableWorkflows` also needs to be updated. Before finishing, ask the user whether they will make the documentation changes themselves or want guidance through making them. Do not require documentation changes for minor, internal, or non-user-visible workflow updates.

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -781,7 +781,7 @@ jobs:
 
       - name: Partition solution projects
         id: partition
-        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/partition-solution-projects@main
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/partition-solution-projects@ReorderPackaging
         with:
           solution-path: ${{ needs.discover_projects.outputs.solution-path }}
 

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -830,7 +830,13 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ env.SIGNING_CLIENT_SECRET }}
         run: |
           # Sign in place so later package builds consume the signed binaries.
-          for pattern in "**/bin/**/*.dll" "**/bin/**/*.exe"; do
+          for extension in dll exe; do
+            if [[ -z "$(find . -type f -path '*/bin/*' -name "*.$extension" -print -quit)" ]]; then
+              echo "No .$extension build outputs to sign."
+              continue
+            fi
+
+            pattern="**/bin/**/*.$extension"
             sign code azure-key-vault "$pattern" \
               --publisher-name "Skyline Communications" \
               --description "Skyline Signing" \

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -661,8 +661,8 @@ jobs:
           path: output/*.deb
 
   # ════════════════════════════════════════════════════════════════
-  # Windows packaging & signing: build all shippable artifacts and
-  # sign everything in one place — DLL/EXE → WiX rebuild → MSI → NuGet → dmapp.
+  # Windows packaging & signing: remaining projects → signed DLL/EXE → WiX/MSI
+  # → staged installers → DataMiner packages → NuGet/DataMiner signing.
   # Runs on every ref except fork PRs (no secrets) and Dependabot, so packaging
   # problems surface before the release tag; the upload jobs below consume the
   # signed artifacts and remain tag-only.
@@ -779,10 +779,17 @@ jobs:
         with:
           repository: ${{ github.repository }}
 
-      - name: Build all artifacts (packaging on, WiX included)
+      - name: Partition solution projects
+        id: partition
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/partition-solution-projects@main
+        with:
+          solution-path: ${{ needs.discover_projects.outputs.solution-path }}
+
+      - name: Build remaining projects
+        if: steps.partition.outputs.remaining-count != '0'
         env:
           OVERRIDE_CATALOG_DOWNLOAD_TOKEN: ${{ secrets.OVERRIDE_CATALOG_DOWNLOAD_TOKEN }}
-          SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
+          SOLUTION_PATH: ${{ steps.partition.outputs.remaining-solution-path }}
           VERSION: ${{ needs.determine_version.outputs.version }}
           INFORMATIONAL_VERSION: ${{ needs.determine_version.outputs.informational-version }}
           NUMERIC_VERSION: ${{ needs.determine_version.outputs.numeric-version }}
@@ -807,11 +814,145 @@ jobs:
             -p:CatalogPublishKeyName="DATAMINER_TOKEN" \
             -p:CatalogDefaultDownloadKeyName="OVERRIDE_CATALOG_DOWNLOAD_TOKEN" \
             -p:SkylineDataMinerSdkDebug="$DEBUG_FLAG" \
-            -p:PackageOutputPath="${GITHUB_WORKSPACE}/_NuGetOutput"
+            -p:PackageOutputPath="${GITHUB_WORKSPACE}/_NuGetOutput" \
+            -p:GenerateDataMinerPackage=false \
+            -p:BuildProjectReferences=false
+        shell: bash
+
+      - name: Sign assemblies
+        if: >-
+          needs.check_oidc.outputs.use-oidc == 'true' &&
+          steps.partition.outputs.remaining-count != '0' &&
+          (steps.partition.outputs.wix-count != '0' || steps.partition.outputs.dataminer-package-count != '0')
+        env:
+          AZURE_TENANT_ID: ${{ env.SIGNING_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ env.SIGNING_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ env.SIGNING_CLIENT_SECRET }}
+        run: |
+          # Sign in place so later package builds consume the signed binaries.
+          for pattern in "**/bin/**/*.dll" "**/bin/**/*.exe"; do
+            sign code azure-key-vault "$pattern" \
+              --publisher-name "Skyline Communications" \
+              --description "Skyline Signing" \
+              --description-url "https://www.skyline.be/" \
+              --azure-key-vault-certificate "$SIGNING_KEY_VAULT_CERTIFICATE" \
+              --azure-key-vault-url "$SIGNING_KEY_VAULT_URL"
+          done
+        shell: bash
+
+      - name: Generate SBOM files for WiX installers
+        if: steps.partition.outputs.wix-count != '0' && github.ref_type == 'tag' && !contains(github.ref_name, '-')
+        env:
+          PACKAGE_VERSION: ${{ needs.determine_version.outputs.version }}
+        run: |
+          dataminer-sbom generate \
+            --solution-path "$GITHUB_WORKSPACE" \
+            --package-version "$PACKAGE_VERSION" \
+            --package-supplier "Skyline Communications" \
+            --output "$GITHUB_WORKSPACE/SBOM"
+        shell: bash
+
+      - name: Inject SBOM into WiX projects
+        if: steps.partition.outputs.wix-count != '0' && github.ref_type == 'tag' && !contains(github.ref_name, '-')
+        env:
+          WIX_SOLUTION_PATH: ${{ steps.partition.outputs.wix-solution-path }}
+        run: |
+          $solutionDirectory = Split-Path -Parent $env:WIX_SOLUTION_PATH
+          $wixProjectDirs = dotnet sln "$env:WIX_SOLUTION_PATH" list |
+            Select-String '\.wixproj' |
+            ForEach-Object { Split-Path -Parent (Join-Path $solutionDirectory $_.ToString().Trim()) }
+          foreach ($wixProjectDir in $wixProjectDirs) {
+            add-file --WixProjDirectory "$wixProjectDir" --includeFilesDirectory "$env:GITHUB_WORKSPACE/SBOM"
+          }
+        shell: pwsh
+
+      - name: Build WiX projects
+        if: steps.partition.outputs.wix-count != '0'
+        env:
+          SOLUTION_PATH: ${{ steps.partition.outputs.wix-solution-path }}
+          VERSION: ${{ needs.determine_version.outputs.version }}
+          INFORMATIONAL_VERSION: ${{ needs.determine_version.outputs.informational-version }}
+          NUMERIC_VERSION: ${{ needs.determine_version.outputs.numeric-version }}
+          PRODUCT_VERSION: ${{ needs.determine_version.outputs.product-version }}
+          CONFIGURATION: ${{ inputs.configuration }}
+        run: |
+          dotnet build "$env:SOLUTION_PATH" `
+            -p:Version="$env:VERSION" `
+            -p:PackageVersion="$env:VERSION" `
+            -p:AssemblyVersion="$env:NUMERIC_VERSION" `
+            -p:FileVersion="$env:NUMERIC_VERSION" `
+            -p:InformationalVersion="$env:INFORMATIONAL_VERSION" `
+            -p:IncludeSourceRevisionInInformationalVersion=false `
+            -p:ProductVersion="$env:PRODUCT_VERSION" `
+            -p:GeneratePackageOnBuild=false `
+            -p:GenerateDataMinerPackage=false `
+            -p:BuildProjectReferences=false `
+            --configuration "$env:CONFIGURATION"
+        shell: pwsh
+
+      - name: Sign installers
+        if: needs.check_oidc.outputs.use-oidc == 'true' && steps.partition.outputs.wix-count != '0'
+        env:
+          AZURE_TENANT_ID: ${{ env.SIGNING_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ env.SIGNING_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ env.SIGNING_CLIENT_SECRET }}
+        run: |
+          sign code azure-key-vault "**/bin/**/*.msi" \
+            --publisher-name "Skyline Communications" \
+            --description "Skyline Signing" \
+            --description-url "https://www.skyline.be/" \
+            --azure-key-vault-certificate "$SIGNING_KEY_VAULT_CERTIFICATE" \
+            --azure-key-vault-url "$SIGNING_KEY_VAULT_URL" \
+            --output "_SignedInstallers"
+        shell: bash
+
+      - name: Stage unsigned installers
+        if: needs.check_oidc.outputs.use-oidc != 'true' && steps.partition.outputs.wix-count != '0'
+        run: |
+          echo "::warning::OIDC is not available - MSI installers are packaged UNSIGNED."
+          mkdir -p _SignedInstallers
+          find . -type f -name '*.msi' -path '*/bin/*' -not -path './_SignedInstallers/*' -exec cp {} _SignedInstallers/ \;
+        shell: bash
+
+      - name: Verify staged installers
+        if: steps.partition.outputs.wix-count != '0'
+        run: |
+          if [ ! -d "_SignedInstallers" ] || [ -z "$(find _SignedInstallers -type f -name '*.msi' -print -quit)" ]; then
+            echo "::error::WiX projects were built, but no MSI exists in _SignedInstallers."
+            exit 1
+          fi
+        shell: bash
+
+      - name: Build DataMiner package projects
+        if: steps.partition.outputs.dataminer-package-count != '0'
+        env:
+          OVERRIDE_CATALOG_DOWNLOAD_TOKEN: ${{ secrets.OVERRIDE_CATALOG_DOWNLOAD_TOKEN }}
+          SOLUTION_PATH: ${{ steps.partition.outputs.dataminer-package-solution-path }}
+          VERSION: ${{ needs.determine_version.outputs.version }}
+          INFORMATIONAL_VERSION: ${{ needs.determine_version.outputs.informational-version }}
+          NUMERIC_VERSION: ${{ needs.determine_version.outputs.numeric-version }}
+          PRODUCT_VERSION: ${{ needs.determine_version.outputs.product-version }}
+          CONFIGURATION: ${{ inputs.configuration }}
+          DEBUG_FLAG: ${{ inputs.debug }}
+        run: |
+          dotnet build "$SOLUTION_PATH" \
+            -p:Version="$VERSION" \
+            -p:PackageVersion="$VERSION" \
+            -p:AssemblyVersion="$NUMERIC_VERSION" \
+            -p:FileVersion="$NUMERIC_VERSION" \
+            -p:InformationalVersion="$INFORMATIONAL_VERSION" \
+            -p:IncludeSourceRevisionInInformationalVersion=false \
+            -p:ProductVersion="$PRODUCT_VERSION" \
+            --configuration "$CONFIGURATION" \
+            -p:CatalogPublishKeyName="DATAMINER_TOKEN" \
+            -p:CatalogDefaultDownloadKeyName="OVERRIDE_CATALOG_DOWNLOAD_TOKEN" \
+            -p:SkylineDataMinerSdkDebug="$DEBUG_FLAG" \
+            -p:PackageOutputPath="${GITHUB_WORKSPACE}/_NuGetOutput" \
+            -p:BuildProjectReferences=false
         shell: bash
 
       - name: Create package name
-        if: needs.discover_projects.outputs.has-dataminer-projects == 'true'
+        if: steps.partition.outputs.dataminer-package-count != '0'
         id: packageName
         env:
           REPO: ${{ github.repository }}
@@ -822,7 +963,7 @@ jobs:
         shell: pwsh
 
       - name: Add SBOM to DataMiner packages
-        if: needs.discover_projects.outputs.has-dataminer-projects == 'true'
+        if: steps.partition.outputs.dataminer-package-count != '0'
         env:
           SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
           PACKAGE_NAME: ${{ steps.packageName.outputs.name }}
@@ -841,117 +982,7 @@ jobs:
           done
         shell: bash
 
-      - name: Generate SBOM files for WiX installers
-        if: needs.discover_projects.outputs.has-wix-projects == 'true' && github.ref_type == 'tag' && !contains(github.ref_name, '-')
-        env:
-          PACKAGE_VERSION: ${{ needs.determine_version.outputs.version }}
-        run: |
-          dataminer-sbom generate \
-            --solution-path "$GITHUB_WORKSPACE" \
-            --package-version "$PACKAGE_VERSION" \
-            --package-supplier "Skyline Communications" \
-            --output "$GITHUB_WORKSPACE/SBOM"
-        shell: bash
-
-      - name: Inject SBOM into WiX projects and rebuild
-        if: needs.discover_projects.outputs.has-wix-projects == 'true' && github.ref_type == 'tag' && !contains(github.ref_name, '-')
-        env:
-          SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
-          VERSION: ${{ needs.determine_version.outputs.version }}
-          INFORMATIONAL_VERSION: ${{ needs.determine_version.outputs.informational-version }}
-          NUMERIC_VERSION: ${{ needs.determine_version.outputs.numeric-version }}
-          PRODUCT_VERSION: ${{ needs.determine_version.outputs.product-version }}
-          CONFIGURATION: ${{ inputs.configuration }}
-        run: |
-          $wixProjectDirs = dotnet sln "$env:SOLUTION_PATH" list | Select-String '\.wixproj' | ForEach-Object { Split-Path -Path $_.ToString().Trim() -Parent }
-          foreach ($wixProjectDir in $wixProjectDirs) {
-            add-file --WixProjDirectory "$wixProjectDir" --includeFilesDirectory "$env:GITHUB_WORKSPACE/SBOM"
-          }
-          # Rebuild so the MSI contains the SBOM.
-          dotnet build "$env:SOLUTION_PATH" `
-            -p:Version="$env:VERSION" `
-            -p:PackageVersion="$env:VERSION" `
-            -p:AssemblyVersion="$env:NUMERIC_VERSION" `
-            -p:FileVersion="$env:NUMERIC_VERSION" `
-            -p:InformationalVersion="$env:INFORMATIONAL_VERSION" `
-            -p:IncludeSourceRevisionInInformationalVersion=false `
-            -p:ProductVersion="$env:PRODUCT_VERSION" `
-            -p:GeneratePackageOnBuild=false `
-            -p:GenerateDataMinerPackage=false `
-            --configuration "$env:CONFIGURATION"
-        shell: pwsh
-
-      - name: Sign assemblies (before the MSI is rebuilt)
-        if: needs.check_oidc.outputs.use-oidc == 'true' && needs.discover_projects.outputs.has-wix-projects == 'true'
-        env:
-          AZURE_TENANT_ID: ${{ env.SIGNING_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ env.SIGNING_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ env.SIGNING_CLIENT_SECRET }}
-        run: |
-          # In-place Authenticode signing (no --output) so the WiX rebuild below
-          # bundles the signed binaries into the MSI. Two invocations on purpose:
-          # brace patterns like *.{dll,exe} are NOT expanded (bash doesn't expand
-          # braces inside quotes, and the sign tool's globber has no brace support).
-          for pattern in "**/bin/**/*.dll" "**/bin/**/*.exe"; do
-            sign code azure-key-vault "$pattern" \
-              --publisher-name "Skyline Communications" \
-              --description "Skyline Signing" \
-              --description-url "https://www.skyline.be/" \
-              --azure-key-vault-certificate "$SIGNING_KEY_VAULT_CERTIFICATE" \
-              --azure-key-vault-url "$SIGNING_KEY_VAULT_URL"
-          done
-        shell: bash
-
-      - name: Rebuild WiX projects with signed binaries
-        if: needs.check_oidc.outputs.use-oidc == 'true' && needs.discover_projects.outputs.has-wix-projects == 'true'
-        env:
-          SOLUTION_PATH: ${{ needs.discover_projects.outputs.solution-path }}
-          VERSION: ${{ needs.determine_version.outputs.version }}
-          NUMERIC_VERSION: ${{ needs.determine_version.outputs.numeric-version }}
-          PRODUCT_VERSION: ${{ needs.determine_version.outputs.product-version }}
-          CONFIGURATION: ${{ inputs.configuration }}
-        run: |
-          # Preserve the original solution's configuration/platform mappings while
-          # limiting the rebuild to WiX projects. Building the solution ensures WiX
-          # uses the same output paths as the initial solution build.
-          $solutionPath = (Resolve-Path "$env:SOLUTION_PATH").Path
-          $solutionDir = Split-Path $solutionPath -Parent
-          $temporarySolutionPath = Join-Path $solutionDir ".wix-build-$([guid]::NewGuid())$(Split-Path $solutionPath -Extension)"
-
-          Copy-Item $solutionPath $temporarySolutionPath
-          try {
-            $nonWixProjects = dotnet sln "$temporarySolutionPath" list | Select-Object -Skip 2 | Where-Object { $_ -and $_ -notlike '*.wixproj' }
-            foreach ($nonWixProject in $nonWixProjects) {
-              dotnet sln "$temporarySolutionPath" remove (Join-Path $solutionDir ($nonWixProject -replace '\\', '/'))
-            }
-
-            dotnet build "$temporarySolutionPath" `
-              -p:Version="$env:VERSION" `
-              -p:ProductVersion="$env:PRODUCT_VERSION" `
-              -p:BuildProjectReferences=false `
-              --configuration "$env:CONFIGURATION"
-          } finally {
-            Remove-Item $temporarySolutionPath -Force -ErrorAction SilentlyContinue
-          }
-        shell: pwsh
-
       - parallel:
-          - name: Sign installers
-            if: needs.check_oidc.outputs.use-oidc == 'true' && needs.discover_projects.outputs.has-wix-projects == 'true'
-            env:
-              AZURE_TENANT_ID: ${{ env.SIGNING_TENANT_ID }}
-              AZURE_CLIENT_ID: ${{ env.SIGNING_CLIENT_ID }}
-              AZURE_CLIENT_SECRET: ${{ env.SIGNING_CLIENT_SECRET }}
-            run: |
-              sign code azure-key-vault "**/bin/**/*.msi" \
-                --publisher-name "Skyline Communications" \
-                --description "Skyline Signing" \
-                --description-url "https://www.skyline.be/" \
-                --azure-key-vault-certificate "$SIGNING_KEY_VAULT_CERTIFICATE" \
-                --azure-key-vault-url "$SIGNING_KEY_VAULT_URL" \
-                --output "_SignedInstallers"
-            shell: bash
-
           - name: Sign NuGet packages
             if: needs.check_oidc.outputs.use-oidc == 'true'
             env:
@@ -973,7 +1004,7 @@ jobs:
             shell: bash
 
           - name: Sign DataMiner packages
-            if: needs.check_oidc.outputs.use-oidc == 'true' && needs.discover_projects.outputs.has-dataminer-projects == 'true'
+            if: needs.check_oidc.outputs.use-oidc == 'true' && steps.partition.outputs.dataminer-package-count != '0'
             env:
               AZURE_TENANT_ID: ${{ env.SIGNING_TENANT_ID }}
               AZURE_CLIENT_ID: ${{ env.SIGNING_CLIENT_ID }}
@@ -987,17 +1018,32 @@ jobs:
                 --debug $env:DEBUG_FLAG
             shell: pwsh
 
-      - name: Fall back to unsigned artifacts (signing not available)
+      - name: Fall back to unsigned NuGet packages
         if: needs.check_oidc.outputs.use-oidc != 'true'
         run: |
-          echo "::warning::OIDC is not available - artifacts are packaged UNSIGNED."
+          echo "::warning::OIDC is not available - NuGet and DataMiner packages remain UNSIGNED."
           if compgen -G "_NuGetOutput/*.nupkg" > /dev/null; then
             mkdir -p _SignedNuGetResults
             cp _NuGetOutput/*.nupkg _SignedNuGetResults/
           fi
-          mkdir -p _SignedInstallers
-          find . -type f -name '*.msi' -path '*/bin/*' -not -path './_SignedInstallers/*' -exec cp {} _SignedInstallers/ \;
         shell: bash
+
+      - name: Clean up partition solutions
+        if: always()
+        env:
+          REMAINING_SOLUTION_PATH: ${{ steps.partition.outputs.remaining-solution-path }}
+          WIX_SOLUTION_PATH: ${{ steps.partition.outputs.wix-solution-path }}
+          DATAMINER_PACKAGE_SOLUTION_PATH: ${{ steps.partition.outputs.dataminer-package-solution-path }}
+        run: |
+          @(
+            $env:REMAINING_SOLUTION_PATH,
+            $env:WIX_SOLUTION_PATH,
+            $env:DATAMINER_PACKAGE_SOLUTION_PATH
+          ) | Where-Object { $_ } | ForEach-Object {
+            Remove-Item -LiteralPath $_ -Force -ErrorAction SilentlyContinue
+          }
+          exit 0
+        shell: pwsh
 
       - name: Detect produced artifacts
         id: detect-artifacts

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -887,7 +887,9 @@ jobs:
           $remainingProjects = dotnet sln $env:REMAINING_SOLUTION_PATH list
           $wixProjects = dotnet sln $env:WIX_SOLUTION_PATH list
           $dataMinerPackageProjects = dotnet sln $env:DATAMINER_PACKAGE_SOLUTION_PATH list
-          if ($remainingProjects -notmatch 'Plain.csproj' -or $wixProjects -notmatch 'Installer.wixproj' -or $dataMinerPackageProjects -notmatch 'Package.csproj') {
+          if (($remainingProjects -join "`n") -notmatch 'Plain.csproj' -or
+              ($wixProjects -join "`n") -notmatch 'Installer.wixproj' -or
+              ($dataMinerPackageProjects -join "`n") -notmatch 'Package.csproj') {
             throw 'Unexpected partition membership.'
           }
 

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -831,6 +831,66 @@ jobs:
             exit 1
           fi
 
+  partition-solution-projects:
+    name: partition-solution-projects
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run offline test corpus
+        shell: pwsh
+        run: ./.github/actions/partition-solution-projects/test.ps1
+
+      - name: Scaffold a mixed solution
+        id: scaffold
+        shell: pwsh
+        run: |
+          $demoDirectory = Join-Path $env:RUNNER_TEMP 'partition-demo'
+          dotnet new sln --name Demo --output $demoDirectory
+          $solutionPath = Get-ChildItem -Path $demoDirectory -File | Where-Object { $_.Extension -in '.sln', '.slnx' } | Select-Object -First 1 -ExpandProperty FullName
+
+          $projects = @{
+            'Plain/Plain.csproj' = '<Project Sdk="Microsoft.NET.Sdk"></Project>'
+            'Installer/Installer.wixproj' = '<Project Sdk="WixToolset.Sdk/6.0.0"></Project>'
+            'Package/Package.csproj' = '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><GenerateDataMinerPackage>true</GenerateDataMinerPackage></PropertyGroup></Project>'
+          }
+
+          foreach ($project in $projects.GetEnumerator()) {
+            $projectPath = Join-Path $demoDirectory $project.Key
+            New-Item -Path (Split-Path $projectPath -Parent) -ItemType Directory -Force | Out-Null
+            Set-Content -Path $projectPath -Value $project.Value
+            dotnet sln $solutionPath add $projectPath
+          }
+
+          "solution-path=$solutionPath" >> $env:GITHUB_OUTPUT
+
+      - name: Invoke composite smoke test
+        id: partition
+        uses: ./.github/actions/partition-solution-projects
+        with:
+          solution-path: ${{ steps.scaffold.outputs.solution-path }}
+
+      - name: Assert partitions
+        shell: pwsh
+        env:
+          REMAINING_SOLUTION_PATH: ${{ steps.partition.outputs.remaining-solution-path }}
+          REMAINING_COUNT: ${{ steps.partition.outputs.remaining-count }}
+          WIX_SOLUTION_PATH: ${{ steps.partition.outputs.wix-solution-path }}
+          WIX_COUNT: ${{ steps.partition.outputs.wix-count }}
+          DATAMINER_PACKAGE_SOLUTION_PATH: ${{ steps.partition.outputs.dataminer-package-solution-path }}
+          DATAMINER_PACKAGE_COUNT: ${{ steps.partition.outputs.dataminer-package-count }}
+        run: |
+          if ($env:REMAINING_COUNT -ne '1' -or $env:WIX_COUNT -ne '1' -or $env:DATAMINER_PACKAGE_COUNT -ne '1') {
+            throw 'Unexpected partition counts.'
+          }
+
+          $remainingProjects = dotnet sln $env:REMAINING_SOLUTION_PATH list
+          $wixProjects = dotnet sln $env:WIX_SOLUTION_PATH list
+          $dataMinerPackageProjects = dotnet sln $env:DATAMINER_PACKAGE_SOLUTION_PATH list
+          if ($remainingProjects -notmatch 'Plain.csproj' -or $wixProjects -notmatch 'Installer.wixproj' -or $dataMinerPackageProjects -notmatch 'Package.csproj') {
+            throw 'Unexpected partition membership.'
+          }
+
   quality-gate-summary:
     name: quality-gate-summary
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request introduces a new GitHub Action, `partition-solution-projects`, which splits a .NET solution into three separate solution files for independent processing of WiX, DataMiner package, and remaining projects. This enables more granular and parallelized CI workflows for solutions containing mixed project types. The action includes robust error handling, clear input/output contracts, and comprehensive documentation.

**New Action: Solution Partitioning**

* Added the `partition-solution-projects` action, which copies a source solution into three uniquely named sibling solutions, each containing only WiX, DataMiner package, or remaining projects. The action does not modify the original solution and handles all supported solution formats (`.sln`, `.slnx`, `.slnf`). [[1]](diffhunk://#diff-2f7f7becfad5ca320d6ff9719de332188c2d28caccc02c3acf008c521fda2a29R1-R40)], [[2]](diffhunk://#diff-99e4c57ef794345f15cf94f000f7488544ef5f514ce68ae4bab6f051a74c3d28R1-R183)])
* Implements strict project classification: WiX projects are identified by `.wixproj` extension, DataMiner packages by a `GenerateDataMinerPackage` XML element set to `true`, and all others are classified as remaining. ([[.github/actions/partition-solution-projects/partition-solution-projects.ps1R1-R183](diffhunk://#diff-99e4c57ef794345f15cf94f000f7488544ef5f514ce68ae4bab6f051a74c3d28R1-R183)])
* Provides robust error handling for missing files, malformed XML, and failed `dotnet` commands, ensuring the action fails safely and cleans up temporary files. ([[.github/actions/partition-solution-projects/partition-solution-projects.ps1R1-R183](diffhunk://#diff-99e4c57ef794345f15cf94f000f7488544ef5f514ce68ae4bab6f051a74c3d28R1-R183)])

**Documentation and Integration**

* Added a comprehensive `README.md` for `partition-solution-projects`, detailing its contract, usage, inputs/outputs, and test instructions. ([[.github/actions/partition-solution-projects/README.mdR1-R66](diffhunk://#diff-f2c191e6a0fd314fa96fe0d556446248d76eec81a5ed9ed1845abadc64722027R1-R66)])
* Updated the main actions index in `.github/actions/README.md` to include the new action with a brief description and reference link. ([[.github/actions/README.mdR51](diffhunk://#diff-52d6b7f655d938f43fd7629a638b5183e3fcd1c3d302b3d32479aac06fdacb84R51)])