### PR TITLE
Fix shared-library build order race in the remaining partition

### DIFF
--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -802,6 +802,13 @@ jobs:
           # versions. WiX uses the dedicated ProductVersion (three fields for stable tags).
           # DefineConstants comes from the job-level env var so the WiX projects can keep
           # their own preprocessor constants (a -p: global would clobber them).
+          # BuildProjectReferences is deliberately left at its default (true) here: a
+          # solution only encodes build order through ProjectSection(ProjectDependencies),
+          # which most solutions don't have, so ProjectReference resolution is the only
+          # thing that orders shared libraries before their consumers. Disabling it lets
+          # MSBuild compile consumers in parallel before the shared library exists
+          # (CS0006: Metadata file '...dll' could not be found). This is the first build
+          # of the job, so there are no signed assemblies to preserve yet.
           dotnet build "$SOLUTION_PATH" \
             -p:Version="$VERSION" \
             -p:PackageVersion="$VERSION" \
@@ -815,8 +822,7 @@ jobs:
             -p:CatalogDefaultDownloadKeyName="OVERRIDE_CATALOG_DOWNLOAD_TOKEN" \
             -p:SkylineDataMinerSdkDebug="$DEBUG_FLAG" \
             -p:PackageOutputPath="${GITHUB_WORKSPACE}/_NuGetOutput" \
-            -p:GenerateDataMinerPackage=false \
-            -p:BuildProjectReferences=false
+            -p:GenerateDataMinerPackage=false
         shell: bash
 
       - name: Sign assemblies


### PR DESCRIPTION
## Problem

Solutions that contain a **shared library consumed by other projects in the same partition** started failing in the `Package & Sign (Windows)` job with:

```
CSC : error CS0006: Metadata file '<shared library>.dll' could not be found
```

This affected several downstream solutions, in one case failing 27 projects at once.

## Root cause

#150 added `-p:BuildProjectReferences=false` to the **first** build step, `Build remaining projects`.

A solution only encodes explicit build order through `ProjectSection(ProjectDependencies)`, which most solutions do not have. Ordering therefore comes solely from `ProjectReference` resolution — which is exactly what `BuildProjectReferences=false` disables. MSBuild then compiled the consumers in parallel before the shared library existed.

The build logs make the race explicit:

| | Before #150 (working) | After #150 (broken) |
|---|---|---|
| Solution | original solution | generated `*.remaining.<guid>` partition |
| `BuildProjectReferences` | default (`true`) | `false` |
| Shared library build output | emitted **before** its consumers | emitted **after** all consumers had already failed |

It is a race rather than a hard failure, which is why it only surfaces on solutions with an intra-partition shared library. Deeper, multi-level reference chains fail more consistently than a flat fan-out. Both `.sln` and `.slnx` solutions are affected.

## Fix

Remove `-p:BuildProjectReferences=false` from `Build remaining projects` and document why it must stay at its default there.

The flag is **deliberately kept** in `Build WiX projects` and `Build DataMiner package projects` — those run *after* `Sign assemblies` and must not rebuild (and thereby overwrite) the already-signed assemblies. The remaining build is the first build of the job, so there is nothing signed to preserve yet, and `-p:GenerateDataMinerPackage=false` still keeps that step from producing packages.

## Validation

- `/test` downstream regression: ✅ all passed.
- Reproduced the failure on an affected downstream solution and confirmed this branch builds it green, with the shared library now built before its consumers and `0 Error(s)`. Later stages were unaffected: `Sign assemblies` and `Build DataMiner package projects` both succeeded and signed artifacts were still produced.

> Follow-up: the `BOOST-DailyRegression-*` repos contain no shared library consumed by sibling projects, which is why `/test` passed on #150 and let this regression through. A dedicated regression repo covering that shape is being added to close the gap.
