### PR TITLE
Add shared-library regression coverage to close the #150 detection gap

### DIFF
--- a/.github/workflows/Test Downstream.yml
+++ b/.github/workflows/Test Downstream.yml
@@ -58,6 +58,12 @@ env:
           "DataMiner App Packages Master Workflow.yml",
           "Master Workflow.yml"
         ]
+      },
+      {
+        "repo": "SkylineCommunications/BOOST-DailyRegression-SharedLibrary",
+        "workflows": [
+          "Master Workflow.yml"
+        ]
       }
     ]
 

--- a/.github/workflows/Test Downstream.yml
+++ b/.github/workflows/Test Downstream.yml
@@ -11,7 +11,10 @@ concurrency:
 # To add a new target repo:
 #   1. Add an entry to DOWNSTREAM_MAP below with the repo and its dependent workflow files
 #      (include transitive dependencies — e.g. if Connector Master calls Connector Master Legacy, list both)
-#   2. Create .github/workflows/test-downstream.yml in that repo (see receiver template)
+#   2. Create the receiver workflow in that repo: .github/workflows/pr-regression.yml,
+#      triggered by `repository_dispatch: types: [test-reusable-workflow]`, calling
+#      SkylineCommunications/BOOST-DailyRegression/.github/workflows/regression.yml@main
+#      with the caller workflow that is pinned to @test-downstream (e.g. pr-ci-cd.yml)
 #   3. Merge the receiver workflow to the target repo's default branch
 
 env:


### PR DESCRIPTION
## Why

The existing `BOOST-DailyRegression-*` repos contain **no project that is referenced by a sibling project**. Nothing in the downstream suite ever depended on MSBuild resolving a `ProjectReference` before compiling its consumer.

That is the exact gap that let #150 through: it passed the entire downstream suite, then broke real solutions with

```
CSC : error CS0006: Metadata file '<shared library>.dll' could not be found
```

and had to be fixed in #151.

## What

New regression repo: **[`SkylineCommunications/BOOST-DailyRegression-SharedLibrary`](https://github.com/SkylineCommunications/BOOST-DailyRegression-SharedLibrary)**, registered here against `Master Workflow.yml`.

Its solution deliberately combines the two shapes that were observed to fail:

```
                      SharedLibrary            <-- consumed by everything
                       /            \
             MidLevelLibrary      Consumer1..6  <-- wide flat fan-out
              /     |     \
     BranchA   BranchB   BranchC                <-- multi-level chain
              \     |     /
                TopLevelApp
```

- **Flat fan-out** reproduces the wide case, where many siblings race one shared library.
- **Four-level chain** reproduces the deep case. This matters: a flat fan-out alone is a *flaky race* that frequently passes, while the transitive chain fails **deterministically**. Without it the regression repo would itself be unreliable.

Every project genuinely consumes types from what it references, so the references can't be optimised away.

## Verification

End-to-end, on the real runner:

| Pinned to | Run | Result |
|---|---|---|
| pre-fix commit (`0ff78eb`) | [31783930026](https://github.com/SkylineCommunications/BOOST-DailyRegression-SharedLibrary/actions/runs/31783930026) | ❌ **failure** — `Build remaining projects`, `CS0006` on `SharedLibrary.dll` **and** `MidLevelLibrary.dll` |
| current `main` (fixed) | [31783890542](https://github.com/SkylineCommunications/BOOST-DailyRegression-SharedLibrary/actions/runs/31783890542) | ✅ **success** |

So the repo demonstrably detects this class of regression rather than just existing. It also reproduces locally with a plain `dotnet build ... -p:BuildProjectReferences=false` (exit 1) vs. without (exit 0) — documented in its README.

The temporary verification branch has been deleted.

## Notes

- `DOWNSTREAM_MAP` JSON validated (7 entries parse).
- The repo follows the sibling layout: `ci-cd.yml` (`@main`), `pr-ci-cd.yml` (`@test-downstream`), `regression.yml` (daily), `pr-regression.yml` (`repository_dispatch` receiver).
- `SONAR_NAME` / `SONAR_TOKEN` / `TEAMS_WEBHOOK` are not yet set on the new repo, so SonarCloud and the Teams notification are inert until someone configures them. The build coverage this PR is about works regardless.
