### PR TITLE
Deduplicate assemblies before signing

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -49,6 +49,7 @@ Usage examples in each action README are sourced from the master workflows in
 | `set-repo-type` | Writes the enterprise `Workflow-Repo-Type` custom property (idempotent read-before-write). | [set-repo-type/README.md](set-repo-type/README.md) |
 | `remove-wix-projects` | Strips WiX projects from a solution for cross-platform CI builds. | [remove-wix-projects/README.md](remove-wix-projects/README.md) |
 | `partition-solution-projects` | Splits a solution into remaining, WiX, and DataMiner package build stages. | [partition-solution-projects/README.md](partition-solution-projects/README.md) |
+| `sign-assemblies` | Signs build outputs through Azure Key Vault, signing each unique file content once and copying the result over its duplicates. | [sign-assemblies/README.md](sign-assemblies/README.md) |
 | `package-debian` | Builds a `.deb` per DxM project from per-project Debian skeletons. | [package-debian/README.md](package-debian/README.md) |
 | `apply-source-code-url` | Fills empty `source_code_url:` fields in catalog manifests. | [apply-source-code-url/README.md](apply-source-code-url/README.md) |
 | `sonarcloud-status` | Checks SonarCloud project status and emits analysis flag. | [sonarcloud-status/README.md](sonarcloud-status/README.md) |

--- a/.github/actions/sign-assemblies/README.md
+++ b/.github/actions/sign-assemblies/README.md
@@ -1,0 +1,115 @@
+# `sign-assemblies`
+
+Authenticode-signs build output assemblies through Azure Key Vault, signing each
+**unique file content only once** and copying the signed result back over its
+byte-identical duplicates.
+
+## Why deduplicate
+
+The Sign CLI signs one file at a time, so two byte-identical files cost two Key
+Vault signing requests for an identical result. A solution copies the same
+third-party assemblies into every project's `bin` folder, which multiplies the
+request count by the number of projects.
+
+In `SkylineCommunications/SLC_S_CentralOps` that meant **2140 files submitted for
+only 141 unique filenames**. The burst trips the per-vault rate limit and the
+whole step fails:
+
+```
+Request was not processed because too many requests were received.
+Reason: VaultRequestTypeLimitReached   Status: 429 (Too Many Requests)
+```
+
+Because Sign CLI retries only three times over five seconds, the failure looks
+flaky — a re-run usually succeeds once the throttling window has reset.
+
+Grouping by SHA-256 before signing removes the redundant requests. **The action
+never leaves a location unsigned:** after the unique representatives are signed,
+each one is copied over every other path that held the same content, so every
+file that would have been signed before still holds signed bytes.
+
+This action deliberately does **not** filter out third-party or already-signed
+assemblies. The set of files that gets signed is unchanged — only the number of
+Key Vault requests goes down.
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `root` | no | `.` | Root directory to scan for build outputs. |
+| `extensions` | no | `dll,exe` | Comma-separated file extensions to sign, without a leading dot. |
+| `path-segment` | no | `bin` | Directory segment a file must live under to count as a build output. |
+| `publisher-name` | no | `Skyline Communications` | Publisher name embedded in the signature. |
+| `description` | no | `Skyline Signing` | Description embedded in the signature. |
+| `description-url` | no | `https://www.skyline.be/` | Description URL embedded in the signature. |
+| `dry-run` | no | `false` | When `true`, report what would be signed without calling the Sign CLI. |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `files-total` | Number of build output files that matched the scan. |
+| `files-signed` | Number of unique file contents submitted to Azure Key Vault. |
+| `files-copied` | Number of duplicates that received a copy of an already signed file. |
+| `batches` | Number of Sign CLI invocations used. |
+
+`files-signed` + `files-copied` always equals `files-total`.
+
+## Required environment
+
+Secrets are passed through `env:`, never `with:`.
+
+| Variable | Purpose |
+| --- | --- |
+| `AZURE_TENANT_ID` | Tenant of the signing service principal. |
+| `AZURE_CLIENT_ID` | Client id of the signing service principal. |
+| `AZURE_CLIENT_SECRET` | Client secret of the signing service principal. |
+| `SIGNING_KEY_VAULT_URL` | URL of the Key Vault holding the certificate. |
+| `SIGNING_KEY_VAULT_CERTIFICATE` | Name of the certificate in the Key Vault. |
+
+The `SIGNING_*` variables are exported to the job environment by the
+[`load-secrets`](../load-secrets/README.md) action. `dry-run: true` needs none of
+them.
+
+## Requirements
+
+- Runs on a Windows runner (Authenticode signing).
+- The `sign` tool must be on `PATH`: `dotnet tool install sign --global --prerelease`.
+
+## Caller permissions
+
+```yaml
+permissions:
+  contents: read
+  id-token: write # only for the azure/login step that precedes this action
+```
+
+## Usage
+
+From [`Master Workflow.yml`](../../workflows/Master%20Workflow.yml):
+
+```yaml
+- name: Sign assemblies
+  id: sign-assemblies
+  if: >-
+    needs.check_oidc.outputs.use-oidc == 'true' &&
+    steps.partition.outputs.remaining-count != '0' &&
+    (steps.partition.outputs.wix-count != '0' || steps.partition.outputs.dataminer-package-count != '0')
+  uses: SkylineCommunications/_ReusableWorkflows/.github/actions/sign-assemblies@main
+  env:
+    AZURE_TENANT_ID: ${{ env.SIGNING_TENANT_ID }}
+    AZURE_CLIENT_ID: ${{ env.SIGNING_CLIENT_ID }}
+    AZURE_CLIENT_SECRET: ${{ env.SIGNING_CLIENT_SECRET }}
+```
+
+## Tests
+
+`test.ps1` runs the whole corpus offline by shadowing the `sign` tool with a stub
+on `PATH`. It asserts the deduplicated counts, that a dry run touches nothing,
+that files outside a `bin` folder and non-matching extensions are left alone,
+and — most importantly — that **every** path that held a duplicated content ends
+up with signed bytes.
+
+```powershell
+pwsh -NoProfile -File .github/actions/sign-assemblies/test.ps1
+```

--- a/.github/actions/sign-assemblies/action.yml
+++ b/.github/actions/sign-assemblies/action.yml
@@ -2,7 +2,7 @@ name: Sign assemblies
 description: >
   Authenticode-signs build output assemblies through Azure Key Vault, signing
   each unique file content only once and copying the signed result over its
-  byte-identical duplicates. Retries with backoff when Key Vault throttles.
+  byte-identical duplicates.
 
 inputs:
   root:

--- a/.github/actions/sign-assemblies/action.yml
+++ b/.github/actions/sign-assemblies/action.yml
@@ -1,0 +1,66 @@
+name: Sign assemblies
+description: >
+  Authenticode-signs build output assemblies through Azure Key Vault, signing
+  each unique file content only once and copying the signed result over its
+  byte-identical duplicates. Retries with backoff when Key Vault throttles.
+
+inputs:
+  root:
+    description: Root directory to scan for build outputs. Defaults to the current directory.
+    required: false
+    default: '.'
+  extensions:
+    description: Comma-separated list of file extensions to sign, without a leading dot.
+    required: false
+    default: 'dll,exe'
+  path-segment:
+    description: Directory segment a file must live under to be treated as a build output.
+    required: false
+    default: 'bin'
+  publisher-name:
+    description: Publisher name embedded in the signature.
+    required: false
+    default: 'Skyline Communications'
+  description:
+    description: Description embedded in the signature.
+    required: false
+    default: 'Skyline Signing'
+  description-url:
+    description: Description URL embedded in the signature.
+    required: false
+    default: 'https://www.skyline.be/'
+  dry-run:
+    description: When 'true', report what would be signed without calling the Sign CLI.
+    required: false
+    default: 'false'
+
+outputs:
+  files-total:
+    description: Number of build output files that matched the scan.
+    value: ${{ steps.sign.outputs.files-total }}
+  files-signed:
+    description: Number of unique file contents submitted to Azure Key Vault.
+    value: ${{ steps.sign.outputs.files-signed }}
+  files-copied:
+    description: Number of duplicate files that received a copy of an already signed file.
+    value: ${{ steps.sign.outputs.files-copied }}
+  batches:
+    description: Number of Sign CLI invocations used to sign the unique files.
+    value: ${{ steps.sign.outputs.batches }}
+
+runs:
+  using: composite
+  steps:
+    - name: Sign assemblies
+      id: sign
+      shell: pwsh
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        SIGN_ROOT: ${{ inputs.root }}
+        SIGN_EXTENSIONS: ${{ inputs.extensions }}
+        SIGN_PATH_SEGMENT: ${{ inputs.path-segment }}
+        SIGN_PUBLISHER_NAME: ${{ inputs.publisher-name }}
+        SIGN_DESCRIPTION: ${{ inputs.description }}
+        SIGN_DESCRIPTION_URL: ${{ inputs.description-url }}
+        SIGN_DRY_RUN: ${{ inputs.dry-run }}
+      run: '& (Join-Path $env:ACTION_PATH "sign-assemblies.ps1")'

--- a/.github/actions/sign-assemblies/sign-assemblies.ps1
+++ b/.github/actions/sign-assemblies/sign-assemblies.ps1
@@ -1,0 +1,235 @@
+$ErrorActionPreference = 'Stop'
+
+function Get-EnvironmentValue {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [string]$Default = ''
+    )
+
+    $value = [System.Environment]::GetEnvironmentVariable($Name)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return $Default
+    }
+
+    return $value.Trim()
+}
+
+function Write-StepOutput {
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Values
+    )
+
+    foreach ($key in $Values.Keys) {
+        Write-Host "$key=$($Values[$key])"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT)) {
+        return
+    }
+
+    $writer = [System.IO.StreamWriter]::new($env:GITHUB_OUTPUT, $true, [System.Text.UTF8Encoding]::new($false))
+    try {
+        foreach ($key in $Values.Keys) {
+            $writer.WriteLine("$key=$($Values[$key])")
+        }
+    } finally {
+        $writer.Dispose()
+    }
+}
+
+# The Sign CLI signs one file at a time, so two byte-identical files cost two
+# Azure Key Vault signing requests for an identical result. Solutions copy the
+# same third-party assemblies into every project's bin folder, which multiplies
+# the request count by the number of projects and trips the per-vault rate limit
+# (HTTP 429 VaultRequestTypeLimitReached). Grouping by content hash lets us sign
+# each distinct file once; every path that held that content still ends up with
+# the signed bytes because the signed representative is copied back over them.
+function Get-SignGroup {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Root,
+
+        [Parameter(Mandatory)]
+        [string[]]$Extension,
+
+        [Parameter(Mandatory)]
+        [string]$PathSegment
+    )
+
+    $separator = [System.IO.Path]::DirectorySeparatorChar
+    $segmentMarker = "$separator$PathSegment$separator"
+
+    $candidates = Get-ChildItem -LiteralPath $Root -Recurse -File -ErrorAction SilentlyContinue |
+        Where-Object { $Extension -contains $_.Extension.TrimStart('.').ToLowerInvariant() } |
+        Where-Object { $_.FullName.Replace('/', $separator).Replace('\', $separator).Contains($segmentMarker) }
+
+    $groups = @()
+    foreach ($group in ($candidates | Group-Object { (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash })) {
+        # Sort so the representative is stable between runs, which keeps re-runs
+        # signing the same path and makes the logs comparable.
+        $paths = @($group.Group | ForEach-Object { $_.FullName } | Sort-Object)
+        $groups += [PSCustomObject]@{
+            Representative = $paths[0]
+            Duplicates     = @($paths | Select-Object -Skip 1)
+        }
+    }
+
+    return $groups
+}
+
+# Windows caps a command line at ~32k characters and a large solution can have
+# thousands of distinct assemblies, so representatives are signed in chunks.
+function Get-SignBatch {
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [string[]]$RelativePath,
+
+        [int]$MaxCommandLength = 24000
+    )
+
+    $batches = @()
+    $current = @()
+    $currentLength = 0
+
+    foreach ($path in $RelativePath) {
+        $cost = $path.Length + 3
+        if ($current.Count -gt 0 -and ($currentLength + $cost) -gt $MaxCommandLength) {
+            $batches += , $current
+            $current = @()
+            $currentLength = 0
+        }
+
+        $current += $path
+        $currentLength += $cost
+    }
+
+    if ($current.Count -gt 0) {
+        $batches += , $current
+    }
+
+    return $batches
+}
+
+function Copy-SignedFile {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Source,
+
+        [Parameter(Mandatory)]
+        [string]$Destination
+    )
+
+    # Build servers (VBCSCompiler, MSBuild node reuse) can still hold a handle on
+    # a freshly produced assembly, so a copy can hit a sharing violation.
+    for ($attempt = 1; $attempt -le 5; $attempt++) {
+        try {
+            Copy-Item -LiteralPath $Source -Destination $Destination -Force
+            return
+        } catch {
+            if ($attempt -eq 5) {
+                throw "Could not copy signed file '$Source' to '$Destination': $($_.Exception.Message)"
+            }
+
+            Start-Sleep -Seconds 2
+        }
+    }
+}
+
+$root = Get-EnvironmentValue -Name 'SIGN_ROOT' -Default '.'
+$rootFullPath = [System.IO.Path]::GetFullPath($root)
+if (-not (Test-Path -LiteralPath $rootFullPath -PathType Container)) {
+    throw "Root directory '$rootFullPath' does not exist."
+}
+
+$extensions = @(
+    (Get-EnvironmentValue -Name 'SIGN_EXTENSIONS' -Default 'dll,exe') -split ',' |
+        ForEach-Object { $_.Trim().TrimStart('.').ToLowerInvariant() } |
+        Where-Object { $_ }
+)
+if ($extensions.Count -eq 0) {
+    throw 'SIGN_EXTENSIONS must contain at least one extension.'
+}
+
+$pathSegment = Get-EnvironmentValue -Name 'SIGN_PATH_SEGMENT' -Default 'bin'
+$dryRun = (Get-EnvironmentValue -Name 'SIGN_DRY_RUN' -Default 'false').Equals('true', [System.StringComparison]::OrdinalIgnoreCase)
+
+$groups = @(Get-SignGroup -Root $rootFullPath -Extension $extensions -PathSegment $pathSegment)
+$duplicateCount = @($groups | ForEach-Object { $_.Duplicates }).Count
+$totalFiles = $groups.Count + $duplicateCount
+
+Write-Host "Found $totalFiles build output file(s) under '$rootFullPath' matching: $($extensions -join ', ')."
+Write-Host "$($groups.Count) unique file content(s) to sign, $duplicateCount duplicate(s) to copy afterwards."
+
+if ($groups.Count -eq 0) {
+    Write-StepOutput -Values @{
+        'files-total'  = 0
+        'files-signed' = 0
+        'files-copied' = 0
+        'batches'      = 0
+    }
+    return
+}
+
+$relativePaths = @($groups | ForEach-Object { [System.IO.Path]::GetRelativePath($rootFullPath, $_.Representative) })
+$batches = @(Get-SignBatch -RelativePath $relativePaths)
+
+if ($dryRun) {
+    Write-Host 'Dry run: not invoking the Sign CLI and not copying representatives.'
+    Write-StepOutput -Values @{
+        'files-total'  = $totalFiles
+        'files-signed' = $groups.Count
+        'files-copied' = $duplicateCount
+        'batches'      = $batches.Count
+    }
+    return
+}
+
+if ($null -eq (Get-Command sign -ErrorAction SilentlyContinue)) {
+    throw "The 'sign' tool must be installed and available on PATH."
+}
+
+$keyVaultUrl = Get-EnvironmentValue -Name 'SIGNING_KEY_VAULT_URL'
+$keyVaultCertificate = Get-EnvironmentValue -Name 'SIGNING_KEY_VAULT_CERTIFICATE'
+if ([string]::IsNullOrWhiteSpace($keyVaultUrl) -or [string]::IsNullOrWhiteSpace($keyVaultCertificate)) {
+    throw 'SIGNING_KEY_VAULT_URL and SIGNING_KEY_VAULT_CERTIFICATE must be set.'
+}
+
+$commonArguments = @(
+    '--base-directory', $rootFullPath
+    '--publisher-name', (Get-EnvironmentValue -Name 'SIGN_PUBLISHER_NAME' -Default 'Skyline Communications')
+    '--description', (Get-EnvironmentValue -Name 'SIGN_DESCRIPTION' -Default 'Skyline Signing')
+    '--description-url', (Get-EnvironmentValue -Name 'SIGN_DESCRIPTION_URL' -Default 'https://www.skyline.be/')
+    '--azure-key-vault-certificate', $keyVaultCertificate
+    '--azure-key-vault-url', $keyVaultUrl
+)
+
+for ($batchIndex = 0; $batchIndex -lt $batches.Count; $batchIndex++) {
+    $batch = @($batches[$batchIndex])
+    Write-Host "Signing batch $($batchIndex + 1) of $($batches.Count) ($($batch.Count) file(s))."
+
+    & sign code azure-key-vault @batch @commonArguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Signing failed with exit code $LASTEXITCODE."
+    }
+}
+
+# Every path that held this content before deduplication must hold the signed
+# bytes afterwards, otherwise packaging would pick up unsigned assemblies.
+foreach ($group in $groups) {
+    foreach ($duplicate in $group.Duplicates) {
+        Copy-SignedFile -Source $group.Representative -Destination $duplicate
+    }
+}
+
+Write-Host "Signed $($groups.Count) unique file(s) and copied the signed result over $duplicateCount duplicate(s)."
+
+Write-StepOutput -Values @{
+    'files-total'  = $totalFiles
+    'files-signed' = $groups.Count
+    'files-copied' = $duplicateCount
+    'batches'      = $batches.Count
+}

--- a/.github/actions/sign-assemblies/test.ps1
+++ b/.github/actions/sign-assemblies/test.ps1
@@ -1,0 +1,225 @@
+$ErrorActionPreference = 'Stop'
+
+# Offline test corpus for sign-assemblies.ps1.
+#
+# The Sign CLI is replaced by a stub on PATH so the deduplication and the
+# copy-back behaviour can be verified without Azure Key Vault. The stub marks
+# every file it is handed, which lets the assertions prove that *all* paths that
+# held a given content before deduplication hold signed content afterwards.
+
+$scriptPath = Join-Path $PSScriptRoot 'sign-assemblies.ps1'
+if (-not (Test-Path -LiteralPath $scriptPath)) {
+    throw "Could not find '$scriptPath'."
+}
+
+$failures = @()
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Because)
+
+    if ("$Expected" -ne "$Actual") {
+        $script:failures += "$Because : expected '$Expected' but got '$Actual'."
+        Write-Host "  [FAIL] $Because (expected '$Expected', got '$Actual')"
+        return
+    }
+
+    Write-Host "  [ OK ] $Because"
+}
+
+function New-TestTree {
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ("sign-assemblies-" + [System.Guid]::NewGuid().ToString('N'))
+
+    # Shared.dll has identical content in three project bin folders, Other.dll is
+    # unique, Ignored.dll sits outside a bin folder, and Notes.txt has a
+    # non-matching extension.
+    $files = @{
+        'ProjectA/bin/Release/Shared.dll'  = 'shared-content'
+        'ProjectB/bin/Release/Shared.dll'  = 'shared-content'
+        'ProjectC/bin/Debug/Shared.dll'    = 'shared-content'
+        'ProjectA/bin/Release/Other.dll'   = 'other-content'
+        'ProjectA/obj/Release/Ignored.dll' = 'ignored-content'
+        'ProjectA/bin/Release/Notes.txt'   = 'not-an-assembly'
+    }
+
+    foreach ($file in $files.GetEnumerator()) {
+        $path = Join-Path $root ($file.Key -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+        New-Item -Path (Split-Path $path -Parent) -ItemType Directory -Force | Out-Null
+        Set-Content -Path $path -Value $file.Value -NoNewline
+    }
+
+    return $root
+}
+
+function New-SignStub {
+    param([Parameter(Mandatory)][string]$Directory)
+
+    New-Item -Path $Directory -ItemType Directory -Force | Out-Null
+
+    # PowerShell resolves .ps1 files found on PATH as commands, so this shadows
+    # the real `sign` tool for the duration of the test.
+    $stub = @'
+$ErrorActionPreference = 'Stop'
+
+$files = @()
+$baseDirectory = (Get-Location).Path
+
+for ($i = 0; $i -lt $args.Count; $i++) {
+    $argument = [string]$args[$i]
+
+    if ($argument -eq '--base-directory') {
+        $baseDirectory = [string]$args[$i + 1]
+        $i++
+        continue
+    }
+
+    if ($argument.StartsWith('--')) {
+        $i++
+        continue
+    }
+
+    if ($argument -in 'code', 'azure-key-vault') {
+        continue
+    }
+
+    $files += $argument
+}
+
+foreach ($file in $files) {
+    $path = if ([System.IO.Path]::IsPathFullyQualified($file)) { $file } else { Join-Path $baseDirectory $file }
+    if (-not (Test-Path -LiteralPath $path)) {
+        Write-Error "Stub received a path that does not exist: $path"
+        exit 1
+    }
+
+    Add-Content -LiteralPath $path -Value '::SIGNED::' -NoNewline
+}
+
+Set-Content -LiteralPath (Join-Path $env:SIGN_STUB_DIR 'invocations.txt') -Value $files -Encoding utf8 -Force
+exit 0
+'@
+
+    Set-Content -Path (Join-Path $Directory 'sign.ps1') -Value $stub
+}
+
+function Invoke-SignAssemblies {
+    param(
+        [Parameter(Mandatory)][string]$Root,
+        [switch]$DryRun,
+        [string]$StubDirectory
+    )
+
+    $outputFile = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString('N') + '.txt')
+    Set-Content -Path $outputFile -Value '' -NoNewline
+
+    $originalPath = $env:PATH
+    try {
+        if ($StubDirectory) {
+            $env:PATH = "$StubDirectory$([System.IO.Path]::PathSeparator)$originalPath"
+            $env:SIGN_STUB_DIR = $StubDirectory
+        }
+
+        $env:SIGN_ROOT = $Root
+        $env:SIGN_DRY_RUN = if ($DryRun) { 'true' } else { 'false' }
+        $env:SIGN_EXTENSIONS = 'dll,exe'
+        $env:SIGN_PATH_SEGMENT = 'bin'
+        $env:SIGNING_KEY_VAULT_URL = 'https://example.vault.azure.net/'
+        $env:SIGNING_KEY_VAULT_CERTIFICATE = 'test-certificate'
+        $env:GITHUB_OUTPUT = $outputFile
+
+        & $scriptPath | Out-Null
+    } finally {
+        $env:PATH = $originalPath
+        Remove-Item Env:\SIGN_STUB_DIR -ErrorAction SilentlyContinue
+        Remove-Item Env:\GITHUB_OUTPUT -ErrorAction SilentlyContinue
+    }
+
+    $outputs = @{}
+    foreach ($line in (Get-Content -LiteralPath $outputFile -ErrorAction SilentlyContinue)) {
+        if ($line -match '^([^=]+)=(.*)$') {
+            $outputs[$Matches[1]] = $Matches[2]
+        }
+    }
+
+    Remove-Item -LiteralPath $outputFile -Force -ErrorAction SilentlyContinue
+    return $outputs
+}
+
+Write-Host 'Test: dry run reports deduplicated counts without touching files.'
+$root = New-TestTree
+try {
+    $outputs = Invoke-SignAssemblies -Root $root -DryRun
+
+    Assert-Equal -Expected 4 -Actual $outputs['files-total'] -Because 'files-total counts every matching build output'
+    Assert-Equal -Expected 2 -Actual $outputs['files-signed'] -Because 'files-signed counts unique contents only'
+    Assert-Equal -Expected 2 -Actual $outputs['files-copied'] -Because 'files-copied counts the duplicates'
+    Assert-Equal -Expected 1 -Actual $outputs['batches'] -Because 'a small corpus fits in one batch'
+
+    $sharedContent = Get-Content -LiteralPath (Join-Path $root 'ProjectA/bin/Release/Shared.dll') -Raw
+    Assert-Equal -Expected 'shared-content' -Actual $sharedContent -Because 'a dry run does not modify files'
+} finally {
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host 'Test: every duplicate location receives the signed bytes.'
+$root = New-TestTree
+$stubDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ("sign-stub-" + [System.Guid]::NewGuid().ToString('N'))
+try {
+    New-SignStub -Directory $stubDirectory
+    $outputs = Invoke-SignAssemblies -Root $root -StubDirectory $stubDirectory
+
+    Assert-Equal -Expected 4 -Actual $outputs['files-total'] -Because 'files-total counts every matching build output'
+    Assert-Equal -Expected 2 -Actual $outputs['files-signed'] -Because 'only unique contents are sent to the signer'
+    Assert-Equal -Expected 2 -Actual $outputs['files-copied'] -Because 'both duplicates are copied back'
+
+    # The core guarantee: deduplication must not leave any location unsigned.
+    $mustBeSigned = @(
+        'ProjectA/bin/Release/Shared.dll'
+        'ProjectB/bin/Release/Shared.dll'
+        'ProjectC/bin/Debug/Shared.dll'
+        'ProjectA/bin/Release/Other.dll'
+    )
+
+    foreach ($relative in $mustBeSigned) {
+        $content = Get-Content -LiteralPath (Join-Path $root $relative) -Raw
+        Assert-Equal -Expected $true -Actual $content.EndsWith('::SIGNED::') -Because "$relative holds signed content"
+    }
+
+    $signedInvocations = @(Get-Content -LiteralPath (Join-Path $stubDirectory 'invocations.txt'))
+    Assert-Equal -Expected 2 -Actual $signedInvocations.Count -Because 'the signer was handed exactly the unique files'
+
+    $ignored = Get-Content -LiteralPath (Join-Path $root 'ProjectA/obj/Release/Ignored.dll') -Raw
+    Assert-Equal -Expected 'ignored-content' -Actual $ignored -Because 'files outside a bin folder are left alone'
+
+    $notes = Get-Content -LiteralPath (Join-Path $root 'ProjectA/bin/Release/Notes.txt') -Raw
+    Assert-Equal -Expected 'not-an-assembly' -Actual $notes -Because 'non-matching extensions are left alone'
+} finally {
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $stubDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host 'Test: an already deduplicated tree signs cleanly a second time.'
+$root = New-TestTree
+$stubDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ("sign-stub-" + [System.Guid]::NewGuid().ToString('N'))
+try {
+    New-SignStub -Directory $stubDirectory
+    Invoke-SignAssemblies -Root $root -StubDirectory $stubDirectory | Out-Null
+    $outputs = Invoke-SignAssemblies -Root $root -StubDirectory $stubDirectory
+
+    # After the first pass the duplicates are byte-identical to their signed
+    # representative, so the grouping must stay stable rather than fan back out.
+    Assert-Equal -Expected 4 -Actual $outputs['files-total'] -Because 'the file count is unchanged on a re-run'
+    Assert-Equal -Expected 2 -Actual $outputs['files-signed'] -Because 're-running still signs only the unique contents'
+} finally {
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $stubDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host ''
+    Write-Host "$($failures.Count) assertion(s) failed:"
+    $failures | ForEach-Object { Write-Host "  - $_" }
+    exit 1
+}
+
+Write-Host ''
+Write-Host 'All sign-assemblies tests passed.'

--- a/.github/workflows/Master Workflow.yml
+++ b/.github/workflows/Master Workflow.yml
@@ -825,32 +825,24 @@ jobs:
             -p:GenerateDataMinerPackage=false
         shell: bash
 
+      # Signs in place so later package builds consume the signed binaries.
+      # Deduplicates by content hash first: solutions copy the same third-party
+      # assemblies into every project's bin folder, and signing each copy
+      # separately bursts past the per-vault Azure Key Vault rate limit
+      # (429 VaultRequestTypeLimitReached). Every path still ends up holding the
+      # signed bytes — the composite copies each signed file back over its
+      # byte-identical duplicates.
       - name: Sign assemblies
+        id: sign-assemblies
         if: >-
           needs.check_oidc.outputs.use-oidc == 'true' &&
           steps.partition.outputs.remaining-count != '0' &&
           (steps.partition.outputs.wix-count != '0' || steps.partition.outputs.dataminer-package-count != '0')
+        uses: SkylineCommunications/_ReusableWorkflows/.github/actions/sign-assemblies@main
         env:
           AZURE_TENANT_ID: ${{ env.SIGNING_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ env.SIGNING_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ env.SIGNING_CLIENT_SECRET }}
-        run: |
-          # Sign in place so later package builds consume the signed binaries.
-          for extension in dll exe; do
-            if [[ -z "$(find . -type f -path '*/bin/*' -name "*.$extension" -print -quit)" ]]; then
-              echo "No .$extension build outputs to sign."
-              continue
-            fi
-
-            pattern="**/bin/**/*.$extension"
-            sign code azure-key-vault "$pattern" \
-              --publisher-name "Skyline Communications" \
-              --description "Skyline Signing" \
-              --description-url "https://www.skyline.be/" \
-              --azure-key-vault-certificate "$SIGNING_KEY_VAULT_CERTIFICATE" \
-              --azure-key-vault-url "$SIGNING_KEY_VAULT_URL"
-          done
-        shell: bash
 
       - name: Generate SBOM files for WiX installers
         if: steps.partition.outputs.wix-count != '0' && github.ref_type == 'tag' && !contains(github.ref_name, '-')

--- a/.github/workflows/Test Downstream.yml
+++ b/.github/workflows/Test Downstream.yml
@@ -56,12 +56,6 @@ env:
         ]
       },
       {
-        "repo": "SkylineCommunications/BOOST-DailyRegression-SharedLibrary",
-        "workflows": [
-          "Master Workflow.yml"
-        ]
-      },
-      {
         "repo": "SkylineCommunications/BOOST-DailyRegression-Skyline.DataMiner.Sdk",
         "workflows": [
           "DataMiner App Packages Master Workflow.yml",

--- a/.github/workflows/Test Downstream.yml
+++ b/.github/workflows/Test Downstream.yml
@@ -56,6 +56,12 @@ env:
         ]
       },
       {
+        "repo": "SkylineCommunications/BOOST-DailyRegression-SharedLibrary",
+        "workflows": [
+          "Master Workflow.yml"
+        ]
+      },
+      {
         "repo": "SkylineCommunications/BOOST-DailyRegression-Skyline.DataMiner.Sdk",
         "workflows": [
           "DataMiner App Packages Master Workflow.yml",

--- a/.github/workflows/Test composite actions.yml
+++ b/.github/workflows/Test composite actions.yml
@@ -893,6 +893,100 @@ jobs:
             throw 'Unexpected partition membership.'
           }
 
+  sign-assemblies:
+    name: sign-assemblies
+    # Windows because the action drives Authenticode signing, and the offline
+    # corpus shadows the `sign` tool so no live Key Vault is needed.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run offline test corpus
+        shell: pwsh
+        run: ./.github/actions/sign-assemblies/test.ps1
+
+      - name: Scaffold build outputs with duplicates
+        id: scaffold
+        shell: pwsh
+        run: |
+          $root = Join-Path $env:RUNNER_TEMP 'sign-demo'
+
+          # Shared.dll is byte-identical in three bin folders, Other.dll is
+          # unique, and Ignored.dll sits outside a bin folder.
+          $files = @{
+            'ProjectA/bin/Release/Shared.dll'  = 'shared-content'
+            'ProjectB/bin/Release/Shared.dll'  = 'shared-content'
+            'ProjectC/bin/Debug/Shared.dll'    = 'shared-content'
+            'ProjectA/bin/Release/Other.dll'   = 'other-content'
+            'ProjectA/obj/Release/Ignored.dll' = 'ignored-content'
+          }
+
+          foreach ($file in $files.GetEnumerator()) {
+            $path = Join-Path $root $file.Key
+            New-Item -Path (Split-Path $path -Parent) -ItemType Directory -Force | Out-Null
+            Set-Content -Path $path -Value $file.Value -NoNewline
+          }
+
+          "root=$root" >> $env:GITHUB_OUTPUT
+
+      - name: Invoke composite smoke test
+        id: sign
+        uses: ./.github/actions/sign-assemblies
+        with:
+          root: ${{ steps.scaffold.outputs.root }}
+          dry-run: 'true'
+
+      - name: Assert deduplicated plan
+        shell: pwsh
+        env:
+          ROOT: ${{ steps.scaffold.outputs.root }}
+          FILES_TOTAL: ${{ steps.sign.outputs.files-total }}
+          FILES_SIGNED: ${{ steps.sign.outputs.files-signed }}
+          FILES_COPIED: ${{ steps.sign.outputs.files-copied }}
+          BATCHES: ${{ steps.sign.outputs.batches }}
+        run: |
+          if ($env:FILES_TOTAL -ne '4') {
+            throw "Expected 4 build outputs but got '$($env:FILES_TOTAL)'."
+          }
+
+          # Three identical Shared.dll plus one unique Other.dll collapse to two
+          # signing requests; the file outside a bin folder is not counted.
+          if ($env:FILES_SIGNED -ne '2' -or $env:FILES_COPIED -ne '2') {
+            throw "Expected 2 signed and 2 copied but got '$($env:FILES_SIGNED)' and '$($env:FILES_COPIED)'."
+          }
+
+          if (([int]$env:FILES_SIGNED + [int]$env:FILES_COPIED) -ne [int]$env:FILES_TOTAL) {
+            throw 'Signed plus copied must account for every build output.'
+          }
+
+          if ($env:BATCHES -ne '1') {
+            throw "Expected a single batch but got '$($env:BATCHES)'."
+          }
+
+          $shared = Get-Content -LiteralPath (Join-Path $env:ROOT 'ProjectA/bin/Release/Shared.dll') -Raw
+          if ($shared -ne 'shared-content') {
+            throw 'A dry run must not modify build outputs.'
+          }
+
+      - name: Assert idempotency
+        id: sign-again
+        uses: ./.github/actions/sign-assemblies
+        with:
+          root: ${{ steps.scaffold.outputs.root }}
+          dry-run: 'true'
+
+      - name: Assert unchanged plan on re-run
+        shell: pwsh
+        env:
+          FIRST_TOTAL: ${{ steps.sign.outputs.files-total }}
+          FIRST_SIGNED: ${{ steps.sign.outputs.files-signed }}
+          SECOND_TOTAL: ${{ steps.sign-again.outputs.files-total }}
+          SECOND_SIGNED: ${{ steps.sign-again.outputs.files-signed }}
+        run: |
+          if ($env:FIRST_TOTAL -ne $env:SECOND_TOTAL -or $env:FIRST_SIGNED -ne $env:SECOND_SIGNED) {
+            throw 'Re-running the action must produce the same plan.'
+          }
+
   quality-gate-summary:
     name: quality-gate-summary
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

`Master Workflow.yml`'s `Sign assemblies` step globs `**/bin/**/*.dll` and hands every match to the Sign CLI, which signs **one file at a time**. Solutions copy the same third-party assemblies into every project's `bin` folder, so the same bytes are sent to Azure Key Vault once per project.

In [SLC_S_CentralOps run 32012369241](https://github.com/SkylineCommunications/SLC_S_CentralOps/actions/runs/32012369241/attempts/1) that meant **2140 files submitted for only 141 unique filenames**:

| Copies | File |
| --- | --- |
| 50 | `ICSharpCode.SharpZipLib.dll` |
| 49 | `Newtonsoft.Json.dll` |
| 49 | `SLNetTypes.dll` |
| 49 | `SLManagedAutomation.dll` |
| … | … |

The burst trips the per-vault rate limit:

```
Request was not processed because too many requests were received.
Reason: VaultRequestTypeLimitReached   Status: 429 (Too Many Requests)
```

Sign CLI retries only 3 times over 5 seconds, then reports `Signing failed with error 0`, which cascades into `-2147024864` (sharing violations on its temp copies) and exits 2. A re-run succeeds once the throttling window resets — which is exactly why this reads as flaky rather than broken.

## Change

Replaces the inline step with a `sign-assemblies` composite action that:

1. Groups build outputs by **SHA-256 content hash**.
2. Signs **one representative per group**.
3. **Copies each signed representative back over every other path that held the same content.**

Step 3 is the important one: the set of files that ends up signed is **identical** to before. No location is left unsigned — only the number of Key Vault requests goes down. `files-signed + files-copied == files-total` is asserted in the tests.

On the regression solution this is 70 build outputs → 41 signing requests. On CentralOps it would be 2140 → ~141, a ~15x reduction.

### Explicitly out of scope

This PR does **not** filter out third-party or already-signed assemblies, and does **not** add retry/backoff. Deduplication first, as requested.

## Verification

`test.ps1` shadows the `sign` tool with a stub on `PATH`, so the full path is verified offline without Key Vault. It asserts:

- deduplicated counts (`files-total` / `files-signed` / `files-copied` / `batches`)
- a dry run modifies nothing
- files outside a `bin` folder and non-matching extensions are untouched
- **every** path that held a duplicated content ends up with signed bytes
- a re-run produces the same plan (idempotency)

All pass locally, and the dry run against the real regression solution reports `70 total / 41 signed / 29 copied`.

## Follow-ups included

- Per-action `README.md`
- Catalog row in `.github/actions/README.md`
- `sign-assemblies` smoke-test job in `Test composite actions.yml` (Windows runner, offline)
- Caller wiring in `Master Workflow.yml` pinned `@main`

## Related

[BOOST-DailyRegression-SharedLibrary#1](https://github.com/SkylineCommunications/BOOST-DailyRegression-SharedLibrary/pull/1) makes the daily regression actually exercise the signing path — it was skipped every day because that repo had no WiX or DataMiner package project.
