### PR TITLE
Potential fix for code scanning alert no. 4: Code injection

### DIFF
--- a/.github/workflows/Test Downstream.yml
+++ b/.github/workflows/Test Downstream.yml
@@ -392,6 +392,7 @@ jobs:
           TARGET_REPOS: ${{ steps.targets.outputs.repos }}
           TAG_SHA: ${{ steps.build-tag.outputs.tag_sha }}
           CORRELATION_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+          HEAD_SHA: ${{ steps.pr-details.outputs.head_sha }}
         run: |
           timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           echo "dispatch_time=$timestamp" >> "$GITHUB_OUTPUT"
@@ -405,7 +406,7 @@ jobs:
               -f event_type='test-reusable-workflow' \
               -f 'client_payload[pr_number]=${{ github.event.issue.number }}' \
               -f 'client_payload[source_repo]=${{ github.repository }}' \
-              -f 'client_payload[head_sha]=${{ steps.pr-details.outputs.head_sha }}' \
+              -f "client_payload[head_sha]=$HEAD_SHA" \
               -f "client_payload[tag_sha]=$TAG_SHA" \
               -f "client_payload[correlation_id]=$CORRELATION_ID" \
               --silent


### PR DESCRIPTION
Potential fix for [https://github.com/SkylineCommunications/_ReusableWorkflows/security/code-scanning/4](https://github.com/SkylineCommunications/_ReusableWorkflows/security/code-scanning/4)

Use the standard GitHub Actions hardening pattern: pass the potentially untrusted value through `env:` and reference it in the shell as `"$VAR"` instead of embedding `${{ ... }}` inside the `run:` block.

Best minimal fix in `.github/workflows/Test Downstream.yml`:
- In step **“Dispatch to target repos”** (around lines 377–401), add a new env variable (e.g. `HEAD_SHA`) set to `${{ steps.pr-details.outputs.head_sha }}`.
- In the `gh api` call, replace:
  - `-f 'client_payload[head_sha]=${{ steps.pr-details.outputs.head_sha }}'`
  with:
  - `-f "client_payload[head_sha]=$HEAD_SHA"`
- Keep behavior identical otherwise.

This removes expression-time injection risk while preserving the same payload value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
