### PR TITLE
Register signing-dedup summary as battery assertion anchor

### DIFF
--- a/.github/instructions/reusable-workflows.instructions.md
+++ b/.github/instructions/reusable-workflows.instructions.md
@@ -63,6 +63,7 @@ The downstream test battery ([TESTING.md](../../TESTING.md)) asserts on **concre
 
 - Artifact names: `SignedNugetPackages`, `SignedDataMinerPackages`, `SignedInstallers`, `debian-package`, `Connector Package`, `validatorResults`, `SBOM`, `Catalog Details`.
 - Job display names: `Discover Project Types`, `Push NuGet Packages`, `Upload to Catalog`, `Package & Sign (Windows)`, `SDK Skyline Quality Gate`, `Artifact Registration and Upload`, `Validate Trigger`, `Migrate wrapper to Master Workflow` (and its step `Create migration PR (dry run)`).
+- Log lines: the `sign-assemblies` summary `N unique file content(s) to sign, M duplicate(s) to copy afterwards` (SharedLibrary's verify asserts M > 0 to guard the Azure 429 deduplication from PR #153).
 - Failure semantics relied on by NegativePaths: multi-solution discovery error, apply-catalog-identifiers rejection, validator quality-gate initial-version rule and missing-results fail-closed path, guard-trigger rejection of `pull_request_target`.
 
 When adding a new input or feature to a master workflow, add a scenario for it (see "Adding coverage" in [TESTING.md](../../TESTING.md)) — a feature without a downstream scenario is unprotected against regressions.

--- a/TESTING.md
+++ b/TESTING.md
@@ -49,7 +49,7 @@ flowchart TD
 | `BOOST-DailyRegression-Automation-SDK` / `-Legacy` | Automation Master — frozen (deprecating) | run conclusion only |
 | `BOOST-DailyRegression-InternalNuGet` | Internal NuGet wrapper → Master Workflow; Wrapper Migration (dry run) | `SignedNugetPackages` artifact; on tags `Push NuGet Packages` job; migration rewrite/idempotency matches repo state |
 | `BOOST-DailyRegression-Skyline.DataMiner.Sdk` | App Packages wrapper → Master Workflow; Update Catalog Details | `SignedDataMinerPackages`; on tags `Upload to Catalog` job; `Catalog Details` artifact contains manifests |
-| `BOOST-DailyRegression-SharedLibrary` | Master Workflow direct (modern inputs), ProjectReference build order, signing dedup | `SignedDataMinerPackages`; on tags catalog upload |
+| `BOOST-DailyRegression-SharedLibrary` | Master Workflow direct (modern inputs), ProjectReference build order, signing dedup | `SignedDataMinerPackages`; signing dedup summary present with duplicates > 0 (Azure 429 guard); on tags catalog upload |
 | `BOOST-DailyRegression-MasterWorkflow` | Master Workflow feature matrix: NuGet path, multi-package + `override-catalog-identifiers`, `.slnf` filtering, `dxm-projects-ubuntu` (.deb), WiX partition, `pull_request` event (synthetic PR), no-filter negative | deep assertions incl. nupkg names (filter honored), manifest ids inside built packages (overrides applied), `.deb` presence |
 | `BOOST-DailyRegression-NegativePaths` | Expected failures: broken build, invalid catalog mapping, validator criticals, missing validator results, `pull_request_target` rejection; plus the connector `solution-filter-name` positive control | run must fail **at the expected job** (`expected-failed-job` in run-and-monitor) |
 


### PR DESCRIPTION
Registers the `sign-assemblies` deduplication summary line as a downstream-battery assertion anchor, following the new signing-dedup guard added to `BOOST-DailyRegression-SharedLibrary`:

- The SharedLibrary fixture (added for #150/#153) deliberately copies identical assembly bytes into every consumer bin, but until now nothing asserted that deduplication actually happens in a live run — a silent grouping regression would stay green there and only resurface as Azure `429 VaultRequestTypeLimitReached` flakiness on large production solutions.
- SharedLibrary's verify job now extracts `N unique file content(s) to sign, M duplicate(s) to copy afterwards` from the `Package & Sign (Windows)` job log and fails when the line is missing or `M == 0`.
- This PR documents that log line in the "Downstream battery coupling" instructions (so it is not reworded without updating the verify job) and updates the SharedLibrary coverage row in TESTING.md.
